### PR TITLE
Add real-robot contract and simulation parity fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ __pycache__/
 
 # pixi (macOS/RoboStack workflow) — the solved environment, not the manifest
 .pixi/
+
+# Raw rosbag corpora (large binary captures; never belong in Git history)
+/bags_x3.zip

--- a/yahboom_rosmaster_description/urdf/robots/rosmaster_x3.urdf.xacro
+++ b/yahboom_rosmaster_description/urdf/robots/rosmaster_x3.urdf.xacro
@@ -139,9 +139,9 @@
     prefix="$(arg prefix)"
     parent="base_link"
     frame_id="imu"
-    xyz_offset="0 0 0.006"
-    rpy_offset="0 0 0"
-    update_rate="15.0"
+    xyz_offset="-0.06 0.01 0.01"
+    rpy_offset="0 3.1415 1.5707"
+    update_rate="10.0"
     topic_name="imu/data"/>
 
   <!-- Gazebo Fortress simulation plugins. gz_ros2_control is read-only for
@@ -201,7 +201,7 @@
         <back_left_joint>$(arg prefix)back_left_wheel_joint</back_left_joint>
         <back_right_joint>$(arg prefix)back_right_wheel_joint</back_right_joint>
         <wheelbase>0.16</wheelbase>
-        <wheel_separation>0.149</wheel_separation>
+        <wheel_separation>${wheel_separation}</wheel_separation>
         <wheel_radius>0.0325</wheel_radius>
         <min_acceleration>-1.0</min_acceleration>
         <max_acceleration>1.0</max_acceleration>

--- a/yahboom_rosmaster_description/urdf/sensors/imu.urdf.xacro
+++ b/yahboom_rosmaster_description/urdf/sensors/imu.urdf.xacro
@@ -19,7 +19,7 @@
         gazebo_material_ambient:='0.1 0.1 0.1 1'
         gazebo_material_diffuse:='0.1 0.1 0.1 1'
         gazebo_material_specular:='0.1 0.1 0.1 1'
-        update_rate:='15.0'
+        update_rate:='10.0'
         gyro_noise_stddev:='0.00873'
         accel_noise_stddev:='0.00175'
         topic_name:='imu/data'

--- a/yahboom_rosmaster_gazebo/CMakeLists.txt
+++ b/yahboom_rosmaster_gazebo/CMakeLists.txt
@@ -22,6 +22,7 @@ install(
     scripts/imu_motion_probe.py
     scripts/lidar_geometry_probe.py
     scripts/motion_profile_divergence_probe.py
+    scripts/real_robot_bag_analyzer.py
     scripts/sensor_contract_probe.py
     scripts/wheel_odometry_resilience_probe.py
     scripts/cmd_vel_watchdog.py

--- a/yahboom_rosmaster_gazebo/config/real_robot_contract.yaml
+++ b/yahboom_rosmaster_gazebo/config/real_robot_contract.yaml
@@ -173,12 +173,15 @@ geometry:
       Wheel collision meshes do not expose a primitive radius; wheel radius
       still needs physical measurement or encoder calibration.
     - >
-      The simulator's own URDF already carries this 0.169 m wheel separation
-      in yahboom_rosmaster_description/urdf/mech/mecanum_wheel.urdf.xacro,
-      but yahboom_rosmaster_description/urdf/robots/rosmaster_x3.urdf.xacro
-      (ros2_control drive) and yahboom_rosmaster_gazebo/scripts/
-      wheel_state_odometry.py both hardcode 0.149 m. This is an internal
-      inconsistency independent of any real-robot measurement question.
+      The simulator now uses the measured 0.169 m wheel separation in both
+      the drive plugin and wheel-state odometry, resolving their former
+      0.149 m inconsistency with the wheel geometry.
+    - >
+      The simulator uses 1080 rays, a 0.05-12 m Fortress range, and a rounded
+      (0.043, 0, 0.110) m mount. It deliberately retains simulation-specific
+      differences: laser_frame rather than laser_link, 5 Hz rather than the
+      measured 7.4 Hz, a pi yaw offset, and a 0.25 m minimum range in Classic
+      to prevent the CPU raycast from detecting the chassis.
 
 command_response:
   confidence: manual_audit

--- a/yahboom_rosmaster_gazebo/config/real_robot_contract.yaml
+++ b/yahboom_rosmaster_gazebo/config/real_robot_contract.yaml
@@ -1,0 +1,218 @@
+# Real ROSMASTER X3 interface contract.
+#
+# Derived from bags_x3.zip: 5 ROS 2 Humble sqlite3 bags, ~62 minutes,
+# 425,513 messages. The archive is untracked (see .gitignore) and never
+# extracted into the repository. Regenerate the underlying measurements with:
+#
+#   ros2 run yahboom_rosmaster_gazebo real_robot_bag_analyzer.py <bag_dir>...
+#
+# `confidence` legend:
+#   measured      - computed directly from bag messages with the analyzer
+#                   above, cross-checked against the 2026-07-26 manual audit.
+#   manual_audit  - taken from the 2026-07-26 manual audit; the method (e.g.
+#                   stable command-window segmentation) is not yet
+#                   reproduced by the analyzer script.
+#   inferred      - a stated inference, not a direct measurement.
+#   absent        - the bags do not contain this data at all.
+#
+# This contract describes the real robot's *recorded ROS interface*. It is
+# not a physical calibration: there is no independent ground truth in these
+# bags, wheel joint positions are always zero, and velocity is never
+# reported. See `calibration_gaps` below.
+
+provenance:
+  source_archive: bags_x3.zip
+  ros_distro: humble
+  storage_format: sqlite3
+  bags:
+    bag_x3_5:
+      description: Mapping run
+      duration_s: 965.9
+      message_count: 110507
+      motion_valid: false
+      note: >
+        Odometry path length is exactly zero and IMU samples are constant
+        for the whole bag while /cmd_vel and /scan keep changing. Excluded
+        from every motion/noise statistic below.
+    bag_x3_6:
+      description: Mapping run
+      duration_s: 802.2
+      message_count: 93002
+      motion_valid: true
+    bag_x3_7:
+      description: Mapping run
+      duration_s: 895.7
+      message_count: 104934
+      motion_valid: true
+    bag_x3_8_cones:
+      description: Blue and red cones course
+      duration_s: 531.1
+      message_count: 58900
+      motion_valid: true
+    bag_x3_9_obstacles:
+      description: Cones and obstacles course
+      duration_s: 548.0
+      message_count: 58170
+      motion_valid: true
+  motion_valid_bags: [bag_x3_6, bag_x3_7, bag_x3_8_cones, bag_x3_9_obstacles]
+  ground_truth: absent
+  ground_truth_note: >
+    No map, world, mocap, tracking-camera, GPS, or AprilTag-pose topic
+    exists in any bag. /tf only carries odom -> base_footprint (a duplicate
+    of /odom) plus wheel transforms; it is not a second pose estimate.
+
+topics:
+  /cmd_vel:
+    type: geometry_msgs/msg/Twist
+    confidence: measured
+    rate_hz: {min: 41.2, max: 62.8}
+    note: rate varies by bag/source (teleop vs. autonomous driving); no header.
+    observed_p90:
+      linear_x: 0.2
+      linear_y: 0.18
+      angular_z: 1.0
+
+  /odom:
+    type: nav_msgs/msg/Odometry
+    confidence: measured
+    frame_id: odom
+    child_frame_id: base_footprint
+    rate_hz: 10.0
+    pose_covariance_xx_yy: 0.000854
+    pose_covariance_yawyaw: 0.000648
+    covariance_behavior: dynamic  # changes on every sample; not a fixed matrix
+    lateral_twist: near_zero      # median |twist.linear.y| ~1e-7 m/s in bags 6-9
+                                   # even while /cmd_vel.linear.y reaches +/-0.4
+    source_node: unknown
+    source_node_note: >
+      Not recorded in the bags. Dynamic, non-trivial covariance suggests a
+      vendor or fused estimator rather than raw wheel odometry, but this
+      remains an inference.
+
+  /joint_states:
+    type: sensor_msgs/msg/JointState
+    confidence: measured
+    names: [front_right_joint, front_left_joint, back_right_joint, back_left_joint]
+    rate_hz: 10.0
+    position: always_zero
+    velocity: never_reported
+    note: placeholder state, not encoder telemetry; do not drive simulator odometry from it.
+
+  /scan:
+    type: sensor_msgs/msg/LaserScan
+    confidence: measured
+    frame_id: laser_link
+    rate_hz: 7.40
+    ray_count: 1080
+    angle_min: -3.14159274
+    angle_max: 3.14159274
+    angle_increment: 0.0058231563
+    range_min: 0.05
+    range_max: 12.0
+    scan_time_s: 0.1343
+    time_increment_s: 0.0001244
+    non_finite_returns_per_scan_median: 85
+
+  /imu/data:
+    type: sensor_msgs/msg/Imu
+    confidence: measured
+    frame_id: imu_link
+    rate_hz: 10.0
+    gravity_convention: negative_z
+    gravity_magnitude_median: {min: 9.800, max: 9.848}
+    orientation_covariance_diag: [0.0025, 0.0025, 0.0025]
+    angular_velocity_covariance_diag: [0.0, 0.0, 0.0]
+    linear_acceleration_covariance_diag: [0.0, 0.0, 0.0]
+    covariance_note: angular_velocity and linear_acceleration covariance fields are not populated by the driver.
+    stationary_noise_stddev:
+      confidence: manual_audit
+      note: >
+        Provisional upper bounds from odom-selected low-motion windows, not a
+        controlled stationary capture; includes vibration and selection error.
+      gyro_xy_rad_s: {min: 0.0075, max: 0.0121}
+      gyro_z_rad_s: {min: 0.0184, max: 0.0263}
+      accel_mps2: {min: 0.15, max: 0.31}
+
+  /camera_info:
+    type: sensor_msgs/msg/CameraInfo
+    confidence: measured
+    frame_id: default_cam
+    frame_note: not connected to the recorded TF tree; robot-side defect, do not imitate.
+    rate_hz: 10.0
+    dimensions: [320, 240]
+    k_matrix: all_zero
+    k_matrix_note: invalid intrinsics; robot-side defect, do not imitate.
+    distortion_model: ""
+
+  /image_raw:
+    type: sensor_msgs/msg/Image
+    confidence: measured
+    frame_id: default_cam
+    encoding: yuv422_yuy2
+    dimensions: [320, 240]
+    rate_hz: {min: 9.2, max: 10.0}
+
+  /robot_description:
+    type: std_msgs/msg/String
+    confidence: measured
+    note: static xacro-flattened URDF, byte-identical across all 5 bags.
+
+geometry:
+  confidence: measured
+  source: recorded /robot_description joint origins (see urdf_geometry in the analyzer report)
+  wheel_x_offset_m: 0.08
+  wheel_y_offset_m: {right: -0.0845, left: 0.084492}
+  wheel_separation_m: 0.168992
+  base_footprint_to_base_link_z_m: 0.0815
+  sensors:
+    laser_link: {parent: base_link, xyz: [0.0435, 0.0000526, 0.11], rpy: [0, 0, 0]}
+    camera_link: {parent: base_link, xyz: [0.057105, 0.0000179, 0.03755], rpy: [0, 0, 0]}
+    imu_link: {parent: base_link, xyz: [-0.06, 0.01, 0.01], rpy: [0, 3.1415, 1.5707]}
+  notes:
+    - >
+      Wheel collision meshes do not expose a primitive radius; wheel radius
+      still needs physical measurement or encoder calibration.
+    - >
+      The simulator's own URDF already carries this 0.169 m wheel separation
+      in yahboom_rosmaster_description/urdf/mech/mecanum_wheel.urdf.xacro,
+      but yahboom_rosmaster_description/urdf/robots/rosmaster_x3.urdf.xacro
+      (ros2_control drive) and yahboom_rosmaster_gazebo/scripts/
+      wheel_state_odometry.py both hardcode 0.149 m. This is an internal
+      inconsistency independent of any real-robot measurement question.
+
+command_response:
+  confidence: manual_audit
+  method: >
+    Stable command-window segmentation: windows where /cmd_vel held a
+    constant single-axis value for a sustained period, then the steady-state
+    median of reported /odom twist on the same axis. Not yet reproduced by
+    real_robot_bag_analyzer.py. Describes the estimator's reported behavior,
+    not the robot's true physical motion -- no ground truth exists in these
+    bags.
+  samples:
+    - {cmd_vx: 0.1, reported_vx: 0.0957}
+    - {cmd_vx: 0.2, reported_vx: 0.1896}
+    - {cmd_vx: 0.3, reported_vx: 0.2906}
+    - {cmd_vx: -0.1, reported_vx: -0.0727}
+    - {cmd_vx: -0.2, reported_vx: -0.1776}
+    - {cmd_wz: 1.0, reported_wz: 0.685}
+    - {cmd_wz: -1.0, reported_wz: -0.507}
+    - {cmd_vy: [0.1, -0.1], reported_vy: ~0.0}
+
+calibration_gaps:
+  confidence: absent
+  missing:
+    - independent external pose (map/world/mocap/AprilTag/GPS)
+    - usable wheel encoder feedback (/joint_states position always zero, velocity never reported)
+  blocks:
+    - true longitudinal or lateral slip
+    - per-wheel traction differences
+    - encoder error
+    - true endpoint or trajectory error
+    - a defensible mu, mu2, slip1, or slip2 for the Gazebo stress profile
+  next_step: >
+    A smaller controlled bag with real per-wheel encoder ticks/RPM and
+    synchronized external pose (motion capture, overhead AprilTags, a total
+    station, a tracking camera, or accurately measured endpoints) across
+    forward, reverse, strafe, diagonal, rotation, arc, stop, and reversal
+    trials.

--- a/yahboom_rosmaster_gazebo/doc/real_robot_contract.md
+++ b/yahboom_rosmaster_gazebo/doc/real_robot_contract.md
@@ -1,0 +1,55 @@
+# Real-robot interface contract
+
+`config/real_robot_contract.yaml` records the ROSMASTER X3's real ROS 2
+interface as observed in `bags_x3.zip`: 5 Humble sqlite3 bags, about 62
+minutes and 425,513 messages total. The archive itself is untracked (see
+`.gitignore`) and is never extracted into the repository; the contract file
+is the durable, reviewable artifact derived from it.
+
+## Regenerating the measurements
+
+`scripts/real_robot_bag_analyzer.py` reads bags directly with `rosbag2_py`
+and never requires full playback:
+
+```bash
+mkdir -p ~/rosbags_x3
+unzip bags_x3.zip 'bags_x3/bag_x3_6/*' -d ~/rosbags_x3
+# ...repeat for the bags you want to include
+
+ros2 run yahboom_rosmaster_gazebo real_robot_bag_analyzer.py \
+  ~/rosbags_x3/bags_x3/bag_x3_6 \
+  ~/rosbags_x3/bags_x3/bag_x3_7 \
+  ~/rosbags_x3/bags_x3/bag_x3_8_cones \
+  ~/rosbags_x3/bags_x3/bag_x3_9_obstacles \
+  --output /tmp/bag_report.yaml
+```
+
+The analyzer emits per-topic rate, frame, and noise statistics plus the
+recorded URDF joint geometry for each bag it is given. It intentionally
+skips `/image_raw` payload bytes (about 93% of on-disk size) and instead
+reads `/camera_info` for resolution/rate and samples only the first few
+`/image_raw` messages for encoding.
+
+`bag_x3_5` is excluded from every motion statistic: its odometry path length
+is exactly zero and its IMU is frozen for the whole recording while
+`/cmd_vel` and `/scan` keep changing, so it cannot represent real motion.
+
+## What the contract is not
+
+The bags contain no independent ground truth (no map, world, mocap,
+tracking-camera, GPS, or AprilTag-pose topic), and `/joint_states` positions
+are always zero with velocity never reported. The contract therefore
+describes the real robot's *recorded ROS interface* — topic names, frames,
+rates, sensor geometry, and the estimator's reported command-response
+behavior — not a physical wheel-slip or encoder calibration. See
+`calibration_gaps` in the contract file for what a future controlled capture
+would need to add.
+
+## Confidence levels
+
+Each contract section is tagged `measured` (computed by the analyzer and
+cross-checked against the original manual audit), `manual_audit` (from the
+2026-07-26 manual audit, not yet reproduced by the analyzer script — for
+example the stable-command-window gain table), `inferred`, or `absent`.
+Prefer promoting `manual_audit` sections into analyzer output over silently
+copying new numbers into the YAML by hand.

--- a/yahboom_rosmaster_gazebo/package.xml
+++ b/yahboom_rosmaster_gazebo/package.xml
@@ -21,6 +21,7 @@
   <exec_depend>python3-yaml</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <depend>rclcpp</depend>
+  <exec_depend>rosbag2_py</exec_depend>
   <depend>ros2_control</depend>
   <exec_depend>gz_ros2_control</exec_depend>
   <exec_depend>ros_gz_sim</exec_depend>

--- a/yahboom_rosmaster_gazebo/scripts/imu_motion_probe.py
+++ b/yahboom_rosmaster_gazebo/scripts/imu_motion_probe.py
@@ -16,6 +16,17 @@ from sensor_msgs.msg import Imu
 from tf2_ros import Buffer, TransformException, TransformListener
 
 
+# imu_link is mounted at rpy (0, pi, pi/2) relative to base_link (real-robot
+# mount parity; see real_robot_contract.yaml). That rotation is a signed-axis
+# permutation: body +X reads on sensor -Y, body +Y reads on sensor -X, and
+# body +Z reads on sensor -Z (confirmed empirically for +Z via stationary
+# gravity, which lands on accel.z ~= -9.8). All IMU vector fields -- linear
+# acceleration, angular velocity, and orientation-derived yaw -- are reported
+# in this same rotated sensor frame, so every body-frame check below reads
+# the mapped sensor axis with its sign flipped back to body-frame terms.
+BODY_TO_SENSOR_LINEAR_AXIS = {"x": "y", "y": "x"}
+
+
 def stamp_seconds(message):
     """Return a message header stamp in seconds."""
     return float(message.header.stamp.sec) + float(message.header.stamp.nanosec) * 1e-9
@@ -221,9 +232,9 @@ class ImuMotionProbe(Node):
             for message in messages
         ]
         gravity = statistics.median(gravity_magnitudes)
-        if acceleration_z < 8.0 or acceleration_z > 11.5:
+        if acceleration_z < -11.5 or acceleration_z > -8.0:
             errors.append(
-                f"stationary gravity must point +Z in imu_link; median az={acceleration_z:.3f}")
+                f"stationary gravity must point -Z in imu_link; median az={acceleration_z:.3f}")
         if abs(acceleration_x) > 0.75 or abs(acceleration_y) > 0.75:
             errors.append(
                 "stationary horizontal acceleration is too large: "
@@ -356,8 +367,9 @@ class ImuMotionProbe(Node):
                 [f"positive {axis} start produced only {len(messages)} IMU messages"],
                 "insufficient data",
             )
+        sensor_axis = BODY_TO_SENSOR_LINEAR_AXIS[axis]
         values = [
-            getattr(message.linear_acceleration, axis)
+            -getattr(message.linear_acceleration, sensor_axis)
             for message in messages
         ]
         positive_values = [value for value in values if value > 0.35]
@@ -393,7 +405,8 @@ class ImuMotionProbe(Node):
         ]
         if len(steady_messages) < 5:
             steady_messages = messages[len(messages) // 2:]
-        yaw_rates = [message.angular_velocity.z for message in steady_messages]
+        # body +Z (yaw) reads on sensor -Z; see BODY_TO_SENSOR_LINEAR_AXIS.
+        yaw_rates = [-message.angular_velocity.z for message in steady_messages]
         median_yaw_rate = statistics.median(yaw_rates)
         positive_fraction = sum(rate > 0.05 for rate in yaw_rates) / len(yaw_rates)
         if median_yaw_rate < 0.15:
@@ -403,8 +416,11 @@ class ImuMotionProbe(Node):
             errors.append(
                 f"only {positive_fraction:.0%} of steady yaw samples have positive wz")
 
-        yaws = [quaternion_rpy(stationary_last.orientation)[2]]
-        yaws.extend(quaternion_rpy(message.orientation)[2] for message in messages)
+        # Orientation is reported in the same rotated sensor frame as the
+        # angular velocity and linear acceleration fields, so its yaw
+        # component is also negated here to read as body-frame yaw.
+        yaws = [-quaternion_rpy(stationary_last.orientation)[2]]
+        yaws.extend(-quaternion_rpy(message.orientation)[2] for message in messages)
         accumulated_yaw = sum(
             shortest_angle(current, previous)
             for previous, current in zip(yaws, yaws[1:])

--- a/yahboom_rosmaster_gazebo/scripts/real_robot_bag_analyzer.py
+++ b/yahboom_rosmaster_gazebo/scripts/real_robot_bag_analyzer.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Derive a topic/frame/rate/noise contract from recorded real-robot bags.
+
+Reads one or more ROS 2 bags directly with rosbag2_py (never full playback),
+computes per-topic rate, frame, and noise statistics, and can emit a
+machine-readable contract YAML consumed by simulator parity work. Designed to
+be re-run against future bags, including a smaller controlled calibration
+capture, without code changes.
+"""
+
+import argparse
+import math
+import statistics
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import rosbag2_py
+import yaml
+from rclpy.serialization import deserialize_message
+from rosidl_runtime_py.utilities import get_message
+
+STRUCTURAL_TOPICS = [
+    "/cmd_vel",
+    "/odom",
+    "/joint_states",
+    "/scan",
+    "/imu/data",
+    "/camera_info",
+    "/tf_static",
+    "/robot_description",
+]
+
+
+def open_reader(bag_path, topics):
+    """Open a filtered SequentialReader over only the requested topics."""
+    reader = rosbag2_py.SequentialReader()
+    reader.open(
+        rosbag2_py.StorageOptions(uri=str(bag_path), storage_id="sqlite3"),
+        rosbag2_py.ConverterOptions("", ""),
+    )
+    reader.set_filter(rosbag2_py.StorageFilter(topics=topics))
+    topic_types = {t.name: t.type for t in reader.get_all_topics_and_types()}
+    return reader, topic_types
+
+
+def iter_messages(bag_path, topics):
+    """Yield (topic, message, bag_timestamp_ns) for the requested topics."""
+    reader, topic_types = open_reader(bag_path, topics)
+    message_classes = {
+        topic: get_message(type_str)
+        for topic, type_str in topic_types.items()
+        if topic in topics
+    }
+    while reader.has_next():
+        topic, raw, bag_t = reader.read_next()
+        message_class = message_classes.get(topic)
+        if message_class is None:
+            continue
+        yield topic, deserialize_message(raw, message_class), bag_t
+
+
+def header_seconds(message):
+    """Return a header timestamp in seconds, or None if unavailable/zero."""
+    stamp = getattr(getattr(message, "header", None), "stamp", None)
+    if stamp is None:
+        return None
+    seconds = float(stamp.sec) + float(stamp.nanosec) * 1e-9
+    return seconds if seconds > 0.0 else None
+
+
+def rate_from_stamps(stamps):
+    """Return the median sample rate in Hz from a strictly-increasing-ish list."""
+    periods = [b - a for a, b in zip(stamps, stamps[1:]) if b > a]
+    if not periods:
+        return None
+    return 1.0 / statistics.median(periods)
+
+
+def percentiles(values, points=(10, 50, 90)):
+    """Return a dict of requested percentiles, or None if too few samples."""
+    if len(values) < 2:
+        return None
+    ordered = sorted(values)
+    result = {}
+    for point in points:
+        index = min(len(ordered) - 1, max(0, round((point / 100.0) * (len(ordered) - 1))))
+        result[f"p{point}"] = ordered[index]
+    return result
+
+
+def quat_to_rpy(x, y, z, w):
+    """Convert a quaternion to roll/pitch/yaw radians (ZYX convention)."""
+    roll = math.atan2(2.0 * (w * x + y * z), 1.0 - 2.0 * (x * x + y * y))
+    sin_pitch = 2.0 * (w * y - z * x)
+    sin_pitch = max(-1.0, min(1.0, sin_pitch))
+    pitch = math.asin(sin_pitch)
+    yaw = math.atan2(2.0 * (w * z + x * y), 1.0 - 2.0 * (y * y + z * z))
+    return roll, pitch, yaw
+
+
+class TopicAccumulator:
+    """Collects generic rate/frame stats plus caller-supplied named metrics."""
+
+    def __init__(self):
+        self.count = 0
+        self.stamps = []
+        self.bag_stamps_s = []
+        self.frame_ids = set()
+        self.metrics = {}
+
+    def note(self, message, bag_t):
+        self.count += 1
+        self.bag_stamps_s.append(bag_t * 1e-9)
+        header_s = header_seconds(message)
+        if header_s is not None:
+            self.stamps.append(header_s)
+        frame_id = getattr(getattr(message, "header", None), "frame_id", None)
+        if frame_id:
+            self.frame_ids.add(frame_id)
+
+    def metric(self, name, value):
+        self.metrics.setdefault(name, []).append(value)
+
+    def rate_hz(self):
+        return rate_from_stamps(self.stamps) or rate_from_stamps(self.bag_stamps_s)
+
+    def summary(self):
+        out = {
+            "message_count": self.count,
+            "frame_ids": sorted(self.frame_ids),
+            "rate_hz": self.rate_hz(),
+        }
+        for name, values in self.metrics.items():
+            if name.startswith("_"):
+                continue
+            numeric = [v for v in values if isinstance(v, (int, float)) and math.isfinite(v)]
+            if not numeric:
+                continue
+            entry = {"median": statistics.median(numeric)}
+            bounds = percentiles(numeric)
+            if bounds:
+                entry.update(bounds)
+            out[name] = entry
+        return out
+
+
+def analyze_cmd_vel(accum, msg, bag_t):
+    accum.count += 1
+    accum.bag_stamps_s.append(bag_t * 1e-9)
+    accum.metric("linear_x", msg.linear.x)
+    accum.metric("linear_y", msg.linear.y)
+    accum.metric("angular_z", msg.angular.z)
+
+
+def analyze_odom(accum, msg, bag_t):
+    accum.note(msg, bag_t)
+    accum.metric("twist_linear_x", msg.twist.twist.linear.x)
+    accum.metric("twist_linear_y", msg.twist.twist.linear.y)
+    accum.metric("twist_angular_z", msg.twist.twist.angular.z)
+    accum.metric("pose_cov_xx", msg.pose.covariance[0])
+    accum.metric("pose_cov_yy", msg.pose.covariance[7])
+    accum.metric("pose_cov_yawyaw", msg.pose.covariance[35])
+    accum.metrics.setdefault("_frame_ids_extra", set()).add(
+        (msg.header.frame_id, msg.child_frame_id))
+    accum.metrics.setdefault("_xy", []).append((msg.pose.pose.position.x, msg.pose.pose.position.y))
+
+
+def path_length(xy_samples):
+    total = 0.0
+    for (x0, y0), (x1, y1) in zip(xy_samples, xy_samples[1:]):
+        total += math.hypot(x1 - x0, y1 - y0)
+    return total
+
+
+def analyze_joint_states(accum, msg, bag_t):
+    accum.note(msg, bag_t)
+    accum.metrics.setdefault("_names", set()).update(msg.name)
+    all_zero = all(p == 0.0 for p in msg.position)
+    accum.metrics.setdefault("_all_positions_zero", []).append(all_zero)
+    accum.metrics.setdefault("_has_velocity", []).append(bool(msg.velocity))
+
+
+def analyze_scan(accum, msg, bag_t):
+    accum.note(msg, bag_t)
+    accum.metric("angle_min", msg.angle_min)
+    accum.metric("angle_max", msg.angle_max)
+    accum.metric("angle_increment", msg.angle_increment)
+    accum.metric("range_min", msg.range_min)
+    accum.metric("range_max", msg.range_max)
+    accum.metric("scan_time", msg.scan_time)
+    accum.metric("time_increment", msg.time_increment)
+    accum.metric("ray_count", len(msg.ranges))
+    non_finite = sum(1 for r in msg.ranges if not math.isfinite(r))
+    accum.metric("non_finite_returns", non_finite)
+
+
+def analyze_imu(accum, msg, bag_t):
+    accum.note(msg, bag_t)
+    accum.metric("accel_x", msg.linear_acceleration.x)
+    accum.metric("accel_y", msg.linear_acceleration.y)
+    accum.metric("accel_z", msg.linear_acceleration.z)
+    accum.metric("gyro_x", msg.angular_velocity.x)
+    accum.metric("gyro_y", msg.angular_velocity.y)
+    accum.metric("gyro_z", msg.angular_velocity.z)
+    accum.metrics.setdefault("_orientation_cov_diag", []).append(
+        tuple(msg.orientation_covariance[i] for i in (0, 4, 8)))
+    accum.metrics.setdefault("_angvel_cov_diag", []).append(
+        tuple(msg.angular_velocity_covariance[i] for i in (0, 4, 8)))
+    accum.metrics.setdefault("_accel_cov_diag", []).append(
+        tuple(msg.linear_acceleration_covariance[i] for i in (0, 4, 8)))
+
+
+def analyze_camera_info(accum, msg, bag_t):
+    accum.note(msg, bag_t)
+    accum.metrics.setdefault("_dims", set()).add((msg.width, msg.height))
+    accum.metrics.setdefault("_k_all_zero", []).append(all(v == 0.0 for v in msg.k))
+    accum.metrics.setdefault("_distortion_model", set()).add(msg.distortion_model)
+
+
+def collect_tf_static(accum, msg, bag_t):
+    accum.count += 1
+    for transform in msg.transforms:
+        translation = transform.transform.translation
+        rotation = transform.transform.rotation
+        rpy = quat_to_rpy(rotation.x, rotation.y, rotation.z, rotation.w)
+        accum.metrics.setdefault("_edges", {})[
+            (transform.header.frame_id, transform.child_frame_id)
+        ] = {
+            "xyz": [translation.x, translation.y, translation.z],
+            "rpy": list(rpy),
+        }
+
+
+def parse_urdf_geometry(urdf_text):
+    """Extract joint origins from a flattened (non-xacro) recorded URDF."""
+    root = ET.fromstring(urdf_text)
+    joints = {}
+    for joint in root.findall("joint"):
+        name = joint.get("name")
+        parent = joint.find("parent")
+        child = joint.find("child")
+        origin = joint.find("origin")
+        xyz = [float(v) for v in (origin.get("xyz") if origin is not None else "0 0 0").split()]
+        rpy = [float(v) for v in (origin.get("rpy") if origin is not None else "0 0 0").split()]
+        joints[name] = {
+            "type": joint.get("type"),
+            "parent": parent.get("link") if parent is not None else None,
+            "child": child.get("link") if child is not None else None,
+            "xyz": xyz,
+            "rpy": rpy,
+        }
+    return joints
+
+
+def analyze_bag(bag_path, image_samples=3):
+    """Return a per-bag statistics dict."""
+    accumulators = {topic: TopicAccumulator() for topic in STRUCTURAL_TOPICS}
+    handlers = {
+        "/cmd_vel": analyze_cmd_vel,
+        "/odom": analyze_odom,
+        "/joint_states": analyze_joint_states,
+        "/scan": analyze_scan,
+        "/imu/data": analyze_imu,
+        "/camera_info": analyze_camera_info,
+        "/tf_static": collect_tf_static,
+    }
+    urdf_text = None
+    for topic, msg, bag_t in iter_messages(bag_path, STRUCTURAL_TOPICS):
+        if topic == "/robot_description":
+            if urdf_text is None:
+                urdf_text = msg.data
+            continue
+        handlers[topic](accumulators[topic], msg, bag_t)
+
+    image_info = analyze_image_samples(bag_path, image_samples)
+
+    result = {topic.strip("/").replace("/", "_"): accum.summary()
+              for topic, accum in accumulators.items() if topic != "/robot_description"}
+
+    odom_accum = accumulators["/odom"]
+    if odom_accum.count:
+        result["odom"]["reported_frames"] = sorted(
+            f"{a} -> {b}" for a, b in odom_accum.metrics.get("_frame_ids_extra", set()))
+        result["odom"]["path_length_m"] = path_length(odom_accum.metrics.get("_xy", []))
+
+    joint_accum = accumulators["/joint_states"]
+    if joint_accum.count:
+        result["joint_states"]["names"] = sorted(joint_accum.metrics.get("_names", set()))
+        result["joint_states"]["all_positions_always_zero"] = all(
+            joint_accum.metrics.get("_all_positions_zero", [False]))
+        result["joint_states"]["any_velocity_reported"] = any(
+            joint_accum.metrics.get("_has_velocity", [False]))
+
+    camera_info_accum = accumulators["/camera_info"]
+    if camera_info_accum.count:
+        result["camera_info"]["dimensions"] = sorted(
+            camera_info_accum.metrics.get("_dims", set()))
+        result["camera_info"]["k_always_zero"] = all(
+            camera_info_accum.metrics.get("_k_all_zero", [False]))
+        result["camera_info"]["distortion_models"] = sorted(
+            m for m in camera_info_accum.metrics.get("_distortion_model", set()))
+
+    imu_accum = accumulators["/imu/data"]
+    if imu_accum.count:
+        orientation_cov = imu_accum.metrics.get("_orientation_cov_diag", [])
+        angvel_cov = imu_accum.metrics.get("_angvel_cov_diag", [])
+        accel_cov = imu_accum.metrics.get("_accel_cov_diag", [])
+        result["imu_data"]["orientation_covariance_diag"] = list(orientation_cov[0]) if orientation_cov else None
+        result["imu_data"]["angular_velocity_covariance_diag"] = list(angvel_cov[0]) if angvel_cov else None
+        result["imu_data"]["linear_acceleration_covariance_diag"] = list(accel_cov[0]) if accel_cov else None
+        gravity_mag = [
+            math.hypot(math.hypot(ax, ay), az)
+            for ax, ay, az in zip(
+                imu_accum.metrics.get("accel_x", []),
+                imu_accum.metrics.get("accel_y", []),
+                imu_accum.metrics.get("accel_z", []))
+        ]
+        if gravity_mag:
+            result["imu_data"]["gravity_magnitude_median"] = statistics.median(gravity_mag)
+
+    tf_static_edges = accumulators["/tf_static"].metrics.get("_edges", {})
+    result["tf_static"] = {
+        f"{parent} -> {child}": edge
+        for (parent, child), edge in sorted(tf_static_edges.items())
+    }
+
+    result["image_raw"] = image_info
+    result["urdf_geometry"] = parse_urdf_geometry(urdf_text) if urdf_text else None
+    return result
+
+
+def analyze_image_samples(bag_path, count):
+    """Sample the first few /image_raw messages without scanning the topic."""
+    if count <= 0:
+        return {"sampled": 0}
+    samples = []
+    for _, msg, _ in iter_messages(bag_path, ["/image_raw"]):
+        samples.append(msg)
+        if len(samples) >= count:
+            break
+    if not samples:
+        return {"sampled": 0}
+    return {
+        "sampled": len(samples),
+        "encodings": sorted({s.encoding for s in samples}),
+        "dimensions": sorted({(s.width, s.height) for s in samples}),
+        "frame_ids": sorted({s.header.frame_id for s in samples}),
+    }
+
+
+def bag_duration_and_count(bag_path):
+    """Read duration/message_count straight from metadata.yaml (cheap)."""
+    metadata_path = Path(bag_path) / "metadata.yaml"
+    with open(metadata_path) as f:
+        info = yaml.safe_load(f)["rosbag2_bagfile_information"]
+    return (
+        info["duration"]["nanoseconds"] * 1e-9,
+        info["message_count"],
+    )
+
+
+def build_report(bag_paths, image_samples):
+    report = {"bags": {}}
+    for bag_path in bag_paths:
+        bag_id = Path(bag_path).name
+        duration_s, message_count = bag_duration_and_count(bag_path)
+        stats = analyze_bag(bag_path, image_samples=image_samples)
+        report["bags"][bag_id] = {
+            "path": str(bag_path),
+            "duration_s": duration_s,
+            "message_count": message_count,
+            "topics": stats,
+        }
+    return report
+
+
+def to_native(value):
+    """Recursively convert numpy scalars/arrays and tuples for plain YAML output."""
+    if isinstance(value, dict):
+        return {to_native(k): to_native(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [to_native(v) for v in value]
+    if hasattr(value, "item") and not isinstance(value, (str, bytes)):
+        return value.item()
+    return value
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("bags", nargs="+", help="Paths to extracted rosbag2 directories")
+    parser.add_argument("--output", type=Path, help="Write the full report as YAML to this path")
+    parser.add_argument(
+        "--image-samples", type=int, default=3,
+        help="Number of leading /image_raw messages to sample for encoding/size (default 3)")
+    args = parser.parse_args()
+
+    report = to_native(build_report(args.bags, args.image_samples))
+
+    if args.output:
+        with open(args.output, "w") as f:
+            yaml.safe_dump(report, f, sort_keys=False, default_flow_style=False)
+        print(f"Wrote report for {len(args.bags)} bag(s) to {args.output}")
+    else:
+        print(yaml.safe_dump(report, sort_keys=False, default_flow_style=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/yahboom_rosmaster_gazebo/scripts/real_robot_bag_analyzer.py
+++ b/yahboom_rosmaster_gazebo/scripts/real_robot_bag_analyzer.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Derive a topic/frame/rate/noise contract from recorded real-robot bags.
+"""
+Derive a topic/frame/rate/noise contract from recorded real-robot bags.
 
 Reads one or more ROS 2 bags directly with rosbag2_py (never full playback),
 computes per-topic rate, frame, and noise statistics, and can emit a
@@ -162,7 +163,10 @@ def analyze_odom(accum, msg, bag_t):
     accum.metric("pose_cov_yawyaw", msg.pose.covariance[35])
     accum.metrics.setdefault("_frame_ids_extra", set()).add(
         (msg.header.frame_id, msg.child_frame_id))
-    accum.metrics.setdefault("_xy", []).append((msg.pose.pose.position.x, msg.pose.pose.position.y))
+    accum.metrics.setdefault("_xy", []).append((
+        msg.pose.pose.position.x,
+        msg.pose.pose.position.y,
+    ))
 
 
 def path_length(xy_samples):
@@ -305,9 +309,15 @@ def analyze_bag(bag_path, image_samples=3):
         orientation_cov = imu_accum.metrics.get("_orientation_cov_diag", [])
         angvel_cov = imu_accum.metrics.get("_angvel_cov_diag", [])
         accel_cov = imu_accum.metrics.get("_accel_cov_diag", [])
-        result["imu_data"]["orientation_covariance_diag"] = list(orientation_cov[0]) if orientation_cov else None
-        result["imu_data"]["angular_velocity_covariance_diag"] = list(angvel_cov[0]) if angvel_cov else None
-        result["imu_data"]["linear_acceleration_covariance_diag"] = list(accel_cov[0]) if accel_cov else None
+        result["imu_data"]["orientation_covariance_diag"] = (
+            list(orientation_cov[0]) if orientation_cov else None
+        )
+        result["imu_data"]["angular_velocity_covariance_diag"] = (
+            list(angvel_cov[0]) if angvel_cov else None
+        )
+        result["imu_data"]["linear_acceleration_covariance_diag"] = (
+            list(accel_cov[0]) if accel_cov else None
+        )
         gravity_mag = [
             math.hypot(math.hypot(ax, ay), az)
             for ax, ay, az in zip(

--- a/yahboom_rosmaster_gazebo/scripts/sensor_contract_probe.py
+++ b/yahboom_rosmaster_gazebo/scripts/sensor_contract_probe.py
@@ -225,7 +225,7 @@ class SensorContractProbe(Node):
 
         rate_contracts = {
             "/scan": (4.5, 5.5),
-            "/imu/data": (12.0, 18.0),
+            "/imu/data": (8.0, 12.0),
             "/cam_1/color/image_raw": (1.7, 2.3),
             "/cam_1/depth/image_raw": (1.7, 2.3),
             "/cam_1/color/camera_info": (1.7, 2.3),

--- a/yahboom_rosmaster_gazebo/scripts/sensor_contract_probe.py
+++ b/yahboom_rosmaster_gazebo/scripts/sensor_contract_probe.py
@@ -24,6 +24,7 @@ EXPECTED_WHEEL_JOINTS = {
     "back_right_wheel_joint",
 }
 CAMERA_HORIZONTAL_FOV = 1.5184
+REQUIRED_DYNAMIC_TF_EDGE = ("odom", "base_footprint")
 
 
 class SensorContractProbe(Node):
@@ -51,6 +52,7 @@ class SensorContractProbe(Node):
             "/tf_static": 1,
         }
         self.messages = {topic: [] for topic in self.required_counts}
+        self.observed_dynamic_tf_edges = set()
         self.started_at = time.monotonic()
         self.first_arrivals = {}
         self._subscription_handles = []
@@ -114,16 +116,27 @@ class SensorContractProbe(Node):
             f"Waiting up to {self.timeout:.1f}s for the standalone sensor contract")
 
     def capture(self, topic, message):
-        """Keep only the number of messages needed by the contract."""
+        """Keep bounded samples and continuously track dynamic TF edges."""
         self.first_arrivals.setdefault(topic, time.monotonic())
+        if topic == "/tf":
+            self.observed_dynamic_tf_edges.update(
+                (
+                    transform.header.frame_id.lstrip("/"),
+                    transform.child_frame_id.lstrip("/"),
+                )
+                for transform in message.transforms
+            )
         if len(self.messages[topic]) < self.required_counts[topic]:
             self.messages[topic].append(message)
 
     def complete(self):
         """Return whether all topics have produced the required samples."""
-        return all(
-            len(self.messages[topic]) >= count
-            for topic, count in self.required_counts.items()
+        return (
+            all(
+                len(self.messages[topic]) >= count
+                for topic, count in self.required_counts.items()
+            )
+            and REQUIRED_DYNAMIC_TF_EDGE in self.observed_dynamic_tf_edges
         )
 
     @staticmethod
@@ -348,12 +361,7 @@ class SensorContractProbe(Node):
             errors.append(
                 f"odom: expected child base_footprint, got {odometry.child_frame_id}")
 
-        dynamic_children = {
-            transform.child_frame_id
-            for message in self.messages["/tf"]
-            for transform in message.transforms
-        }
-        if "base_footprint" not in dynamic_children:
+        if REQUIRED_DYNAMIC_TF_EDGE not in self.observed_dynamic_tf_edges:
             errors.append("/tf: odom -> base_footprint transform was not observed")
 
         static_children = {

--- a/yahboom_rosmaster_gazebo/scripts/wheel_state_odometry.py
+++ b/yahboom_rosmaster_gazebo/scripts/wheel_state_odometry.py
@@ -40,7 +40,7 @@ class WheelStateOdometry(Node):
         self.declare_parameter("back_left_joint", "back_left_wheel_joint")
         self.declare_parameter("back_right_joint", "back_right_wheel_joint")
         self.declare_parameter("wheel_base", 0.16)
-        self.declare_parameter("wheel_separation", 0.149)
+        self.declare_parameter("wheel_separation", 0.169)
         self.declare_parameter("wheel_radius", 0.0325)
         self.declare_parameter("max_wheel_position_jump", 2.0 * math.pi)
         self.declare_parameter("odom_frame_id", "odom")

--- a/yahboom_rosmaster_gazebo/test/imu_motion.launch.py
+++ b/yahboom_rosmaster_gazebo/test/imu_motion.launch.py
@@ -36,7 +36,7 @@ def generate_test_description():
             "timeout": 45.0,
             "stationary_samples": 20,
             "warmup_samples": 5,
-            "nominal_rate": 15.0,
+            "nominal_rate": 10.0,
             "linear_command": 0.4,
             "linear_duration": 0.7,
             "yaw_command": 0.5,


### PR DESCRIPTION
## Summary

- add a reusable ROS bag analyzer plus the measured real-robot interface contract and supporting notes
- align simulated wheel separation and IMU mounting/rate with the measured robot contract
- make the sensor contract wait for the exact `odom -> base_footprint` dynamic TF edge
- ignore the local raw bag archive and bring the analyzer into the repository lint contract

## Why

The simulator had an internal wheel-separation mismatch and an IMU configuration that differed from recorded hardware. The sensor contract also stopped after a fixed number of `/tf` messages, so faster competing broadcasters could crowd out the required odometry edge and cause a timing-dependent failure.

This branch was replayed after merging #2. Its conflict resolution retains #2's working LiDAR geometry and documents the remaining intentional simulator-versus-hardware differences.

## Impact

This provides a reproducible real-hardware baseline for future parity work, makes the current wheel/IMU model more representative, and removes the observed dynamic-TF test race without increasing stored message volume.

## Validation

- `colcon build --symlink-install` — 9 packages built
- `colcon test --return-code-on-test-failure`
- `colcon test-result --verbose` — 139 tests, 0 errors, 0 failures, 6 skipped
