### PR TITLE
Rename obs world files to victimas

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,9 +300,9 @@ ros2 launch yahboom_rosmaster_bringup rosmaster_x3_sim.launch.py \
 | World | Description |
 |-------|-------------|
 | `laberinto_simple.world` | Small 6x6 m maze with three internal partition walls |
-| `laberinto_simple_obs.world` | `laberinto_simple.world` layout plus three color-marker obstacle cubes (two red, one blue; 0.25x0.25x0.3 m, with collision) for camera/LiDAR color-detection workshops |
+| `laberinto_simple_victimas.world` | `laberinto_simple.world` layout plus three color-marker obstacle cubes (two red, one blue; 0.25x0.25x0.3 m, with collision) for camera/LiDAR color-detection workshops |
 | `laberinto_1.world` | Larger, more convoluted maze exported from Gazebo's Building Editor |
-| `laberinto_1_obs.world` | `laberinto_1.world` layout plus four color-marker obstacle cubes (three red, one blue; 0.25x0.25x0.3 m, one shrunk to 0.15x0.15x0.3 m to fit a ~0.31 m gap between two walls) tucked into narrow passages -- diagonal column corridor, small side room, stub-wall zigzag, and a wall gap -- so the robot has to enter a corridor before it can see and identify the color |
+| `laberinto_1_victimas.world` | `laberinto_1.world` layout plus four color-marker obstacle cubes (three red, one blue; 0.25x0.25x0.3 m, one shrunk to 0.15x0.15x0.3 m to fit a ~0.31 m gap between two walls) tucked into narrow passages -- diagonal column corridor, small side room, stub-wall zigzag, and a wall gap -- so the robot has to enter a corridor before it can see and identify the color |
 | `maze_1_6x5.world` | plywood_mazes maze 1, 6x5 m |
 | `maze_2_6x5.world` | plywood_mazes maze 2, 6x5 m |
 | `maze_3_6x6.world` | plywood_mazes maze 3, 6x6 m -- ships a matching occupancy map at `maps/maze_3.yaml` |
@@ -652,13 +652,13 @@ The following simulator limitations remain:
   measured covariance.
 - `simple_room.world` and `willowgarage.world` are retained migration assets;
   they are not supported Fortress worlds.
-- The eight maze worlds (`laberinto_simple.world`, `laberinto_simple_obs.world`,
-  `laberinto_1.world`, `laberinto_1_obs.world`, `maze_1_6x5.world`,
+- The eight maze worlds (`laberinto_simple.world`, `laberinto_simple_victimas.world`,
+  `laberinto_1.world`, `laberinto_1_victimas.world`, `maze_1_6x5.world`,
   `maze_2_6x5.world`, `maze_3_6x6.world`, `maze_4_metal_6x6.world`) are
   usable Fortress worlds but are not part of the automated headless
   contract above. Only `maze_3_6x6.world` ships a matching occupancy map
   (`maps/maze_3.yaml`); the others have no pre-built map. The obstacle
-  cubes in `laberinto_simple_obs.world` and `laberinto_1_obs.world` have
+  cubes in `laberinto_simple_victimas.world` and `laberinto_1_victimas.world` have
   collision but are not part of any map either -- they are meant to be
   detected live via camera/LiDAR, not pre-mapped.
 - Multi-robot operation and real-hardware bringup are not provided.

--- a/yahboom_rosmaster_gazebo/worlds/laberinto_1_victimas.world
+++ b/yahboom_rosmaster_gazebo/worlds/laberinto_1_victimas.world
@@ -1,5 +1,5 @@
 <sdf version='1.7'>
-  <world name='laberinto_1_obs'>
+  <world name='laberinto_1_victimas'>
     <gravity>0 0 -9.8</gravity>
     <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
     <atmosphere type='adiabatic'/>

--- a/yahboom_rosmaster_gazebo/worlds/laberinto_simple_victimas.world
+++ b/yahboom_rosmaster_gazebo/worlds/laberinto_simple_victimas.world
@@ -1,5 +1,5 @@
 <sdf version='1.7'>
-  <world name='laberinto_simple_obs'>
+  <world name='laberinto_simple_victimas'>
     <gravity>0 0 -9.8</gravity>
     <physics type='ode'>
       <max_step_size>0.001</max_step_size>


### PR DESCRIPTION
## Summary
- Rename `laberinto_simple_obs.world` → `laberinto_simple_victimas.world` and `laberinto_1_obs.world` → `laberinto_1_victimas.world` (via `git mv`, history preserved)
- Update each world's internal `<world name='...'>` attribute to match the new filename
- Update README.md references to the old names (maze worlds table and limitations section)

## Why
The `_obs` suffix currently marks worlds with color-marker cubes used for camera/LiDAR detection workshops (victims), not physical navigation obstacles. Renaming to `_victimas` frees up `_obs`/`obstaculos` naming for a future world type with real obstacles the robot must avoid.