### PR TITLE
Fix stuck/spawned-on-wall maze worlds, recenter floors, split CONTRIBUTING.md out of README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,25 +42,25 @@ The highest-leverage places to jump in, straight from the project's own
 [Current Project Status](README.md#current-project-status) and
 [Troubleshooting](README.md#troubleshooting) sections:
 
-- 🧩 **Add or improve a maze world.** Only `maze_3_6x6.world` ships a matching
+- **Add or improve a maze world.** Only `maze_3_6x6.world` ships a matching
   occupancy map (`maps/maze_3.yaml`) — the other seven maze worlds have none.
   The obstacle cubes in `laberinto_simple_victimas.world` and
   `laberinto_1_victimas.world` are meant to be detected live via camera/LiDAR,
   not pre-mapped, so tooling or challenge worlds around live detection are
   welcome too.
-- 🎯 **Help calibrate the drivetrain.** The default `stress` wheel-contact
+- **Help calibrate the drivetrain.** The default `stress` wheel-contact
   profile is deterministic but uncalibrated — it must not be described as
   reproducing the physical ROSMASTER X3 until its contact values are fitted
   against synchronized wheel odometry and external ground truth. The `ideal`
   profile is the current zero-slip baseline.
-- 📷 **Help calibrate sensors.** Camera, LiDAR, and IMU output is nominal
+- **Help calibrate sensors.** Camera, LiDAR, and IMU output is nominal
   simulation data, not yet validated against the physical robot; IMU
   covariance arrays are all zero (ROS's "unknown," not a measured value).
-- 🍏 **Improve macOS / Gazebo Classic parity.** The Apple Silicon backend
+- **Improve macOS / Gazebo Classic parity.** The Apple Silicon backend
   trades away the Gazebo GUI and LiDAR on Fortress for a Classic backend that
   restores both — see [What does not work on macOS](README.md#what-does-not-work-on-macos)
   for the current gap list.
-- 🐛 **Fix bugs.** See [Troubleshooting](README.md#troubleshooting) for known
+- **Fix bugs.** See [Troubleshooting](README.md#troubleshooting) for known
   rough edges (stale workspace overlays, controller/odometry readiness, etc.).
 
 ## Repository Layout

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,126 @@
+# Contributing to yahboom_rosmaster
+
+Thanks for being here. `yahboom_rosmaster` is the ROSMASTER X3 simulator/digital
+twin behind AIR Club UdeSA's [Challenge JAR](https://github.com/AIRclub-UdeSA/jar_site) —
+every team competing at JAR 2026 (Jornada Argentina de Robótica, Rosario) builds
+and tests their robot behavior against this world before it ever touches a
+physical robot. It gets better when more people run it, break it, and extend it.
+
+## Getting set up
+
+- Ubuntu 22.04
+- [ROS 2 Humble](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debs.html)
+- Gazebo Fortress 6
+- `git`, `colcon`, and `rosdep`
+
+```bash
+sudo apt update
+sudo apt install -y git python3-colcon-common-extensions python3-rosdep ros-humble-ros-gz
+
+mkdir -p ~/rosmaster_ws/src
+cd ~/rosmaster_ws/src
+git clone https://github.com/AIRclub-UdeSA/yahboom_rosmaster.git
+
+cd ~/rosmaster_ws
+source /opt/ros/humble/setup.bash
+rosdep update
+rosdep install --from-paths src --ignore-src -r -y --rosdistro humble
+
+colcon build --symlink-install
+source install/setup.bash
+```
+
+Apple Silicon Macs use a RoboStack/pixi environment instead — see
+[macOS (Apple Silicon)](README.md#macos-apple-silicon) in the README. Once
+you're built, the [Quick Start](README.md#quick-start) section covers launching
+the simulator, driving the robot, and picking a world (including the maze
+worlds under [Maze Worlds](README.md#maze-worlds)).
+
+## Good first contributions
+
+The highest-leverage places to jump in, straight from the project's own
+[Current Project Status](README.md#current-project-status) and
+[Troubleshooting](README.md#troubleshooting) sections:
+
+- 🧩 **Add or improve a maze world.** Only `maze_3_6x6.world` ships a matching
+  occupancy map (`maps/maze_3.yaml`) — the other seven maze worlds have none.
+  The obstacle cubes in `laberinto_simple_victimas.world` and
+  `laberinto_1_victimas.world` are meant to be detected live via camera/LiDAR,
+  not pre-mapped, so tooling or challenge worlds around live detection are
+  welcome too.
+- 🎯 **Help calibrate the drivetrain.** The default `stress` wheel-contact
+  profile is deterministic but uncalibrated — it must not be described as
+  reproducing the physical ROSMASTER X3 until its contact values are fitted
+  against synchronized wheel odometry and external ground truth. The `ideal`
+  profile is the current zero-slip baseline.
+- 📷 **Help calibrate sensors.** Camera, LiDAR, and IMU output is nominal
+  simulation data, not yet validated against the physical robot; IMU
+  covariance arrays are all zero (ROS's "unknown," not a measured value).
+- 🍏 **Improve macOS / Gazebo Classic parity.** The Apple Silicon backend
+  trades away the Gazebo GUI and LiDAR on Fortress for a Classic backend that
+  restores both — see [What does not work on macOS](README.md#what-does-not-work-on-macos)
+  for the current gap list.
+- 🐛 **Fix bugs.** See [Troubleshooting](README.md#troubleshooting) for known
+  rough edges (stale workspace overlays, controller/odometry readiness, etc.).
+
+## Repository Layout
+
+| Package / Directory | Contents |
+|---------------------|----------|
+| `yahboom_rosmaster` | Repository metapackage |
+| `yahboom_rosmaster_bringup` | Canonical simulator launch entrypoints and helpers |
+| `yahboom_rosmaster_description` | Xacro/URDF, kinematic parameters, visual/collision meshes, and RViz configs |
+| `yahboom_rosmaster_gazebo` | Fortress worlds, bridge configs, simulator launch, watchdog, odometry, and test probes |
+| `yahboom_rosmaster_msgs` | Custom interface definitions |
+| `yahboom_robostack_M_silycon` | macOS Apple Silicon pixi + Gazebo Classic simulation environment |
+| `dockerfiles` | Docker container setup (`Dockerfile`, `container.sh`) for isolated Linux simulation |
+
+Read [Simulator Architecture](README.md#simulator-architecture) before touching
+the command flow, the bridge, or the watchdog — it documents how `/cmd_vel`
+gets from ROS to Gazebo and back, and how odometry/TF are assembled.
+
+## Coding style
+
+- Python nodes are linted with `ament_flake8` and `ament_pep257` across every
+  package — keep docstrings and formatting consistent with that.
+- ROS 2 launch files follow the existing Python launch API style in
+  `yahboom_rosmaster_bringup` and `yahboom_rosmaster_gazebo` — match the
+  surrounding structure rather than inventing a new pattern.
+- SDF/world/xacro files: match the surrounding indentation and comment
+  density. Comment the *why* (a tuned physics value, a workaround for a
+  simulator quirk) — not the obvious *what*.
+- Prefer small, reviewable commits.
+
+## Pull requests
+
+Changes to `main` must go through a pull request:
+
+1. Create a feature branch (`git checkout -b feature/my-change`) and push it.
+2. Before opening the PR, run the [Development Checks](README.md#development-checks)
+   from the workspace root — `colcon build`, `colcon test`, `py_compile`,
+   `xacro` + `check_urdf`, and `rosdep check` — and keep them green.
+3. If you change runtime behavior (a launch arg, a topic, a default profile),
+   update the [Current Project Status](README.md#current-project-status)
+   section of the README in the same PR.
+4. If you add a world, model, or asset, make sure you have the right to
+   redistribute it and note its origin (see [Provenance](README.md#provenance)
+   for the pattern this repo already follows).
+5. Describe what you changed and how you verified it — a screenshot or a
+   short recording is welcome for anything visual, matching the media already
+   in `docs/media/`.
+6. At least 1 approval from another contributor is required before merging.
+7. Resolve all review comments before merging.
+8. New commits after an approval will require re-approval.
+9. Direct pushes to `main` are blocked, including for repo admins.
+
+## Ground rules
+
+- This simulator is what every JAR team calibrates their challenge behavior
+  against — don't overstate fidelity. If a profile, sensor model, or world is
+  uncalibrated or nominal, say so, the same way the README already does.
+- Changes to shared worlds, the robot model, or launch defaults affect every
+  team's environment at once. Flag breaking changes clearly in the PR
+  description rather than assuming they'll be discovered downstream.
+- Be decent to each other. Assume good faith, keep it constructive.
+- By contributing, you agree your contributions are licensed under the
+  BSD-3-Clause license already declared in each package's `LICENSE` file.

--- a/README.md
+++ b/README.md
@@ -682,14 +682,8 @@ command is received or the simulation is stopped.
 
 ## Contributing
 
-Changes to `main` must go through a pull request:
-
-1. Create a feature branch (`git checkout -b feature/my-change`)
-2. Push your branch and open a PR against `main`
-3. At least 1 approval from another contributor is required before merging
-4. Resolve all review comments before merging
-5. New commits after an approval will require re-approval
-6. Direct pushes to `main` are blocked, including for repo admins
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the dev setup, good first issues,
+coding style, and the pull request process.
 
 ## Provenance
 

--- a/yahboom_rosmaster_gazebo/models/floor_parquet2/model.sdf
+++ b/yahboom_rosmaster_gazebo/models/floor_parquet2/model.sdf
@@ -26,13 +26,13 @@
         <geometry>
           <plane>
             <normal>0 0 1</normal>
-            <size>8 8</size>
+            <size>9 9</size>
           </plane>
         </geometry>
         <material>
-          <ambient>0.85 0.85 0.85 1</ambient>
-          <diffuse>0.85 0.85 0.85 1</diffuse>
-          <specular>0.1 0.1 0.1 1</specular>
+          <ambient>0.35 0.22 0.13 1</ambient>
+          <diffuse>0.55 0.35 0.20 1</diffuse>
+          <specular>0.05 0.05 0.05 1</specular>
         </material>
       </visual>
     </link>

--- a/yahboom_rosmaster_gazebo/models/maze_1_tags/model.sdf
+++ b/yahboom_rosmaster_gazebo/models/maze_1_tags/model.sdf
@@ -5,25 +5,13 @@
     <static>true</static>
     <link name='tags'>
 
-     <collision name='collision'>
-     <!-- In Gazebo 7 there appears to be a bug that causes an inconsistency between the visual collision on a plane and the collision phisics -->
-  <!-- <pose>-6 1.5 1.5 0 1.5708 0</pose> --> <!-- correct pose for the visualization of collisions, active by selecting "view -> collisions" -->
-       <pose>1.0 1.0 -5.8 0 1.5708 0</pose> <!-- correct pose for the simulated collision physics -->
-        <geometry>
-          <plane>
-            <normal>1 0 0</normal>
-            <size>2 2</size>
-          </plane>
-        </geometry>
-        <surface>
-          <friction>
-            <ode>
-              <mu>0.2</mu>
-              <mu2>.2</mu2>
-            </ode>
-          </friction>
-        </surface>
-     </collision>
+     <!-- No collision: these are flat visual markers for camera perception.
+          A stale collision plane inherited from a Gazebo 7 Classic bug workaround
+          used to live here at pose "1.0 1.0 -5.8 ...". SDF planes are treated as
+          effectively infinite half-spaces by the physics engine regardless of the
+          <size> tag, so that orphaned plane was silently destabilizing contact
+          resolution for the whole world (robot commands produced ~0 net motion
+          under the default 'stress' wheel profile even far from any wall). -->
 
 <!-- Row 0, outer wall along increasing x axis (y:0) -->
 <!-- Tags 0 to 9 -->

--- a/yahboom_rosmaster_gazebo/models/maze_2_tags/model.sdf
+++ b/yahboom_rosmaster_gazebo/models/maze_2_tags/model.sdf
@@ -5,25 +5,13 @@
     <static>true</static>
     <link name='tags'>
 
-     <collision name='collision'>
-     <!-- In Gazebo 7 there appears to be a bug that causes an inconsistency between the visual collision on a plane and the collision phisics -->
-  <!-- <pose>-6 1.5 1.5 0 1.5708 0</pose> --> <!-- correct pose for the visualization of collisions, active by selecting "view -> collisions" -->
-       <pose>1.0 1.0 -5.8 0 1.5708 0</pose> <!-- correct pose for the simulated collision physics -->
-        <geometry>
-          <plane>
-            <normal>1 0 0</normal>
-            <size>2 2</size>
-          </plane>
-        </geometry>
-        <surface>
-          <friction>
-            <ode>
-              <mu>0.2</mu>
-              <mu2>.2</mu2>
-            </ode>
-          </friction>
-        </surface>
-     </collision>
+     <!-- No collision: these are flat visual markers for camera perception.
+          A stale collision plane inherited from a Gazebo 7 Classic bug workaround
+          used to live here at pose "1.0 1.0 -5.8 ...". SDF planes are treated as
+          effectively infinite half-spaces by the physics engine regardless of the
+          <size> tag, so that orphaned plane was silently destabilizing contact
+          resolution for the whole world (robot commands produced ~0 net motion
+          under the default 'stress' wheel profile even far from any wall). -->
 
 <!-- Row 0, outer wall along increasing x axis (y:0) -->
 <!-- Tags 0 to 9 -->

--- a/yahboom_rosmaster_gazebo/models/maze_3_tags/model.sdf
+++ b/yahboom_rosmaster_gazebo/models/maze_3_tags/model.sdf
@@ -5,25 +5,13 @@
     <static>true</static>
     <link name='tags'>
 
-     <collision name='collision'>
-     <!-- In Gazebo 7 there appears to be a bug that causes an inconsistency between the visual collision on a plane and the collision phisics -->
-  <!-- <pose>-6 1.5 1.5 0 1.5708 0</pose> --> <!-- correct pose for the visualization of collisions, active by selecting "view -> collisions" -->
-       <pose>1.0 1.0 -5.8 0 1.5708 0</pose> <!-- correct pose for the simulated collision physics -->
-        <geometry>
-          <plane>
-            <normal>1 0 0</normal>
-            <size>2 2</size>
-          </plane>
-        </geometry>
-        <surface>
-          <friction>
-            <ode>
-              <mu>0.2</mu>
-              <mu2>.2</mu2>
-            </ode>
-          </friction>
-        </surface>
-     </collision>
+     <!-- No collision: these are flat visual markers for camera perception.
+          A stale collision plane inherited from a Gazebo 7 Classic bug workaround
+          used to live here at pose "1.0 1.0 -5.8 ...". SDF planes are treated as
+          effectively infinite half-spaces by the physics engine regardless of the
+          <size> tag, so that orphaned plane was silently destabilizing contact
+          resolution for the whole world (robot commands produced ~0 net motion
+          under the default 'stress' wheel profile even far from any wall). -->
 
 <!-- Row 0, outer wall along increasing x axis (y:0) -->
 <!-- Tags 0 to 9 -->

--- a/yahboom_rosmaster_gazebo/models/wooden_joint/model.sdf
+++ b/yahboom_rosmaster_gazebo/models/wooden_joint/model.sdf
@@ -83,7 +83,7 @@
             <ode>
               <soft_cfm>0</soft_cfm>
               <soft_erp>0.2</soft_erp>
-              <kp>1e+13</kp>
+              <kp>1e+8</kp>
               <kd>1</kd>
               <max_vel>0.01</max_vel>
               <min_depth>0</min_depth>
@@ -93,7 +93,7 @@
               <split_impulse_penetration_threshold>-0.01</split_impulse_penetration_threshold>
               <soft_cfm>0</soft_cfm>
               <soft_erp>0.2</soft_erp>
-              <kp>1e+13</kp>
+              <kp>1e+8</kp>
               <kd>1</kd>
             </bullet>
           </contact>

--- a/yahboom_rosmaster_gazebo/worlds/maze_1_6x5.world
+++ b/yahboom_rosmaster_gazebo/worlds/maze_1_6x5.world
@@ -3,9 +3,9 @@
   <world name="maze_6x5_v1">
 
     <physics type="ode">
-      <max_step_size>0.00625</max_step_size>
+      <max_step_size>0.001</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>160</real_time_update_rate>
+      <real_time_update_rate>1000</real_time_update_rate>
       <gravity>0 0 -9.8</gravity>
       <!--   <gravity>0 0 0</gravity> -->
     </physics>
@@ -80,21 +80,24 @@
     </light>
 
     <!-- A wooden parquet ground plane -->
+    <!-- Centered on the maze's world-frame bounding box (x:[-1.5,4.5], y:[-3.5,1.5]) -->
     <include>
       <uri>model://floor_parquet2</uri>
-      <pose>0 0 0 0 0 0</pose>
+      <pose>1.5 -1.0 0 0 0 0</pose>
     </include>
 
     <!-- A maze made of plywood panels -->
+    <!-- Offset chosen so the robot spawn point (world 0,0) lands in the fully
+         open pass-through cell at local (1.5, 3.5) instead of inside a wall. -->
     <include>
       <uri>model://maze_1_6x5</uri>
-      <pose>-2.5 -2.5 0 0 0 0</pose>
+      <pose>-1.5 -3.5 0 0 0 0</pose>
     </include>
 
     <!-- A set of tag36h11 AprilTags -->
     <include>
       <uri>model://maze_1_tags</uri>
-      <pose>-2.5 -2.5 0 0 0 0</pose>
+      <pose>-1.5 -3.5 0 0 0 0</pose>
     </include>
 
   </world>

--- a/yahboom_rosmaster_gazebo/worlds/maze_2_6x5.world
+++ b/yahboom_rosmaster_gazebo/worlds/maze_2_6x5.world
@@ -3,9 +3,9 @@
   <world name="maze_6x5_v2">
 
     <physics type="ode">
-      <max_step_size>0.00625</max_step_size>
+      <max_step_size>0.001</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>160</real_time_update_rate>
+      <real_time_update_rate>1000</real_time_update_rate>
       <gravity>0 0 -9.8</gravity>
       <!--   <gravity>0 0 0</gravity> -->
     </physics>
@@ -80,21 +80,24 @@
     </light>
 
     <!-- A wooden parquet ground plane -->
+    <!-- Centered on the maze's world-frame bounding box (x:[-1.5,4.5], y:[-3.5,1.5]) -->
     <include>
       <uri>model://floor_parquet2</uri>
-      <pose>0 0 0 0 0 0</pose>
+      <pose>1.5 -1.0 0 0 0 0</pose>
     </include>
 
     <!-- A maze made of plywood panels -->
+    <!-- Offset chosen so the robot spawn point (world 0,0) lands in the fully
+         open pass-through cell at local (1.5, 3.5) instead of inside a wall. -->
     <include>
       <uri>model://maze_2_6x5</uri>
-      <pose>-2.5 -2.5 0 0 0 0</pose>
+      <pose>-1.5 -3.5 0 0 0 0</pose>
     </include>
 
     <!-- A set of tag36h11 AprilTags -->
     <include>
       <uri>model://maze_2_tags</uri>
-      <pose>-2.5 -2.5 0 0 0 0</pose>
+      <pose>-1.5 -3.5 0 0 0 0</pose>
     </include>
 
   </world>

--- a/yahboom_rosmaster_gazebo/worlds/maze_3_6x6.world
+++ b/yahboom_rosmaster_gazebo/worlds/maze_3_6x6.world
@@ -3,9 +3,9 @@
   <world name="maze_6x6_v1">
 
     <physics type="ode">
-      <max_step_size>0.00625</max_step_size>
+      <max_step_size>0.001</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>160</real_time_update_rate>
+      <real_time_update_rate>1000</real_time_update_rate>
       <gravity>0 0 -9.8</gravity>
       <!--   <gravity>0 0 0</gravity> -->
     </physics>
@@ -89,21 +89,27 @@
     </light>
 
     <!-- A wooden parquet ground plane -->
+    <!-- Centered on the maze's world-frame bounding box (x:[-2.5,3.5], y:[-3.5,2.5]) -->
     <include>
       <uri>model://floor_parquet2</uri>
-      <pose>0 0.5 0 0 0 0</pose>
+      <pose>0.5 -0.5 0 0 0 0</pose>
     </include>
 
     <!-- A maze made of plywood panels -->
+    <!-- Offset chosen so the robot spawn point (world 0,0) lands in the fully
+         open pass-through cell at local (2.5, 3.5) instead of inside a wall.
+         NOTE: this shifts the maze relative to maps/maze_3.yaml -- that Nav2
+         map was captured against the old offset and needs to be re-recorded
+         (or given a matching origin) before it is used for localization. -->
     <include>
       <uri>model://maze_3_6x6</uri>
-      <pose>-3 -2.5 0 0 0 0</pose>
+      <pose>-2.5 -3.5 0 0 0 0</pose>
     </include>
 
     <!-- A set of tag36h11 AprilTags that match the panel positions -->
     <include>
       <uri>model://maze_3_tags</uri>
-      <pose>-3 -2.5 0 0 0 0</pose>
+      <pose>-2.5 -3.5 0 0 0 0</pose>
     </include>
 
   </world>

--- a/yahboom_rosmaster_gazebo/worlds/maze_4_metal_6x6.world
+++ b/yahboom_rosmaster_gazebo/worlds/maze_4_metal_6x6.world
@@ -3,9 +3,9 @@
   <world name="maze_4_metal_6x6">
 
     <physics type="ode">
-      <max_step_size>0.00625</max_step_size>
+      <max_step_size>0.001</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <real_time_update_rate>160</real_time_update_rate>
+      <real_time_update_rate>1000</real_time_update_rate>
       <gravity>0 0 -9.8</gravity>
       <!--   <gravity>0 0 0</gravity> -->
     </physics>
@@ -90,22 +90,25 @@
     </light>
 
     <!-- A wooden parquet ground plane -->
+    <!-- Centered on the maze's world-frame bounding box (x:[-2.5,3.5], y:[-3.5,2.5]) -->
     <include>
       <uri>model://floor_parquet2</uri>
-      <pose>0 0.5 0 0 0 0</pose>
+      <pose>0.5 -0.5 0 0 0 0</pose>
     </include>
 
     <!-- A maze made of plywood panels -->
+    <!-- Offset chosen so the robot spawn point (world 0,0) lands in the fully
+         open pass-through cell at local (2.5, 3.5) instead of inside a wall. -->
     <include>
       <uri>model://maze_4_metal_6x6</uri>
-      <pose>-3 -2.5 0 0 0 0</pose>
+      <pose>-2.5 -3.5 0 0 0 0</pose>
     </include>
 
     <!-- A set of tag36h11 AprilTags that match the panel positions -->
     <!--
     <include>
       <uri>model://maze_3_tags</uri>
-      <pose>-3 -2.5 0 0 0 0</pose>
+      <pose>-2.5 -3.5 0 0 0 0</pose>
     </include>
     -->
   </world>


### PR DESCRIPTION
## Summary

- Fixes the 4 plywood/metal maze worlds (`maze_1_6x5`, `maze_2_6x5`, `maze_3_6x6`, `maze_4_metal_6x6`), which had two independent bugs:
  - **Spawn on a wall**: the robot always spawns at world `(0,0)`, which landed inside a wall cell in all four worlds. Re-pointed each maze's include pose so `(0,0)` lands in a fully open pass-through cell instead.
  - **Near-zero movement under the default `stress` wheel profile** (maze_1/2/3): the AprilTag models (`maze_1_tags`/`2`/`3`) carried a stale collision plane at `z=-5.8`, a leftover Gazebo 7 Classic bug workaround. SDF planes are treated as effectively infinite half-spaces regardless of `<size>`, so that orphaned plane silently destabilized contact resolution for the whole world — the robot's wheels spun but it never translated. Removed it (the tags are visual-only markers, they don't need collision).
  - Also lowered `max_step_size` `0.00625 → 0.001` in all four maze worlds to match the rest of the project's worlds, and softened `wooden_joint`'s contact stiffness (`kp 1e13 → 1e8`) as defensive hardening.
- Recenters `floor_parquet2` under each maze's new bounding box — it had stayed at the old center after the spawn-offset fix, leaving part of the maze floating past the visible floor tile — and switches its color from near-white to brown so walls/floor/robot are actually distinguishable in the GUI.
- Splits the README's `## Contributing` section (6 bullet points, no onboarding path) into a standalone `CONTRIBUTING.md`: dev setup, good-first-contribution pointers pulled from the existing "Current Project Status" / "Troubleshooting" sections, repo layout, coding style, the original PR rules, and the AIR Club / Challenge JAR context for why this simulator exists. The README's Contributing section is now a short pointer to it.

## Note

`maze_3_6x6`'s offset changed, so `maps/maze_3.yaml` no longer lines up with the world and needs to be re-captured before it's used with Nav2.

## Test plan

- [x] Launched each of the 4 maze worlds headless and confirmed clean, non-explosive spawn via raw Gazebo pose (`ign topic -e -t /world/<name>/dynamic_pose/info`).
- [x] Drove forward and rotated in each of the 4 worlds under the default `stress` profile and confirmed real translation/rotation (previously ~0 in maze_1/2/3).
- [x] Verified visually via Gazebo GUI screenshots (maze_1, maze_3): floor fully covers the maze, correct brown color, robot sitting in open space.
