### PR TITLE
Superseded: geometry moved to #26; ground truth tracked in #19

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ Gazebo GUI.
 | `use_sim_time` | `true` | Use the Gazebo simulation clock; keep enabled for the supported workflow |
 | `motion_profile` | `stress` | Wheel contact model: uncalibrated `stress` or zero-slip `ideal` |
 | `motion_bias` | `false` | Add randomized command drift when enabled |
+| `ground_truth_frame` | `auto` | Display `ground_truth_base` in odom, then freeze it in map if SLAM appears; use `odom` to disable the switch |
 
 ## Controlling the Robot
 
@@ -407,7 +408,11 @@ a physical ROSMASTER X3. See
   `wheel_state_odometry.py`.
 - `odom -> base_footprint` is published by `wheel_state_odometry.py`.
 - `/ground_truth/odom` is the timestamped Gazebo world pose of the simulated
-  chassis. It is measurement-only and does not publish a TF edge.
+  chassis. It is measurement-only and does not claim a robot TF edge.
+- `ground_truth_tf.py` publishes the separate `ground_truth_base` diagnostic
+  frame. It aligns nonzero spawn poses with odom and freezes its map alignment
+  when SLAM appears, so later `map -> odom` corrections do not move truth. See
+  [Ground truth and localization frames](yahboom_rosmaster_gazebo/doc/ground_truth.md).
 - Robot link transforms are published by `robot_state_publisher`.
 
 ## Working ROS Interfaces
@@ -419,7 +424,7 @@ a physical ROSMASTER X3. See
 | `/cmd_vel_gz` | `geometry_msgs/msg/Twist` | — | Internal watchdog output bridged to Gazebo |
 | `/joint_states` | `sensor_msgs/msg/JointState` | `base_link` / 30 Hz | Wheel joint positions and velocities |
 | `/odom` | `nav_msgs/msg/Odometry` | `odom` -> `base_footprint` / 30 Hz | Wheel-state odometry |
-| `/ground_truth/odom` | `nav_msgs/msg/Odometry` | `world` -> `base_footprint` / 50 Hz | Measurement-only Gazebo ground truth; not TF |
+| `/ground_truth/odom` | `nav_msgs/msg/Odometry` | `world` -> `base_footprint` / 50 Hz | Raw measurement-only Gazebo ground truth; the separate display helper publishes only `ground_truth_base` |
 | `/tf` | `tf2_msgs/msg/TFMessage` | — | Dynamic transforms |
 | `/tf_static` | `tf2_msgs/msg/TFMessage` | — | Static robot transforms |
 | `/scan` | `sensor_msgs/msg/LaserScan` | `laser_link` / 5 Hz | 1080-sample 2D LiDAR scan |
@@ -504,12 +509,13 @@ known-geometry and commanded-motion gates. Together they validate ten-message
 delivery, nominal rates, first-message latency, timestamped TF, RGB-D geometry,
 registered color/depth frame origins, LiDAR geometry and handedness, IMU axes,
 mecanum wheel signs, odometry/TF agreement, and odometry
-rewind/discontinuity handling. They also verify the ground-truth topic and the
-ideal-versus-stress motion-profile contract:
+rewind/discontinuity handling. They also verify the raw ground-truth contract,
+nonzero-spawn and changing-map display alignment, and the ideal-versus-stress
+motion-profile contract:
 
 ```bash
 colcon test --packages-select yahboom_rosmaster_gazebo \
-  --ctest-args -R '^(sensor_contract_.*|depth_geometry|ground_truth_contract|motion_profile_.*|lidar_geometry|imu_motion|base_feedback|wheel_odometry_resilience)$' \
+  --ctest-args -R '^(sensor_contract_.*|depth_geometry|ground_truth_.*|motion_profile_.*|lidar_geometry|imu_motion|base_feedback|wheel_odometry_resilience)$' \
   --output-on-failure
 colcon test-result --verbose
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -30,8 +30,8 @@ these items.
 
 ## Physics and runtime architecture
 
-- [ ] Evaluate correcting the physical wheel joint and collision centres to
-  match the assembled CAD and the drive plugin's 0.169 m wheel separation.
+- [x] Correct the physical wheel joint and collision centres to match the
+  measured real-robot geometry and the drive plugin's 0.169 m wheel separation.
 - [ ] Evaluate Gazebo's native joint-state publisher as a separate architectural
   change, including publication rate, headers, startup, and shutdown behavior.
 - [ ] Evaluate renderer visibility masks only if raw sensor messages show robot
@@ -41,7 +41,21 @@ these items.
 
 ## Automated contracts
 
-- [ ] Add a focused description contract test covering links, joints, sensor
+- [x] Add a focused description contract test covering links, joints, sensor
   frames, collisions, inertia, plugins, wheel origins, and installed visuals.
 - [ ] Repeat motion-profile, wheel-odometry, TF, LiDAR, RGB-D, IMU, and headless
   launch checks after each accepted physics or sensor change.
+
+## Ground truth and SLAM
+
+### Acceptance gate for the ground-truth change
+
+- [x] Preserve raw Gazebo ground truth in `world` while aligning the separate
+  `ground_truth_base` diagnostic frame for nonzero spawn poses and SLAM maps.
+- [x] Add a synthetic regression proving that later `map -> odom` corrections
+  do not move the fixed ground-truth trajectory.
+- [ ] Validate the corrected diagnostic frame end to end with
+  `yahboom_rosmaster_slam`, including map startup and an intentionally visible
+  wheel-odometry error. Keep the pull request in draft until this passes.
+- [ ] Define restart behavior if SLAM deliberately creates a new map coordinate
+  system during the same simulator process.

--- a/yahboom_rosmaster_bringup/launch/rosmaster_x3_sim.launch.py
+++ b/yahboom_rosmaster_bringup/launch/rosmaster_x3_sim.launch.py
@@ -54,6 +54,13 @@ def generate_launch_description():
         default_value="true",
         description="Use simulation clock"
     )
+    ground_truth_frame_arg = DeclareLaunchArgument(
+        "ground_truth_frame",
+        default_value="auto",
+        description=(
+            "Ground-truth display frame: auto, odom, map, or another "
+            "localization frame")
+    )
 
     include_sim = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(fortress_launch),
@@ -65,6 +72,7 @@ def generate_launch_description():
             "motion_profile": LaunchConfiguration("motion_profile"),
             "motion_bias": LaunchConfiguration("motion_bias"),
             "use_sim_time": LaunchConfiguration("use_sim_time"),
+            "ground_truth_frame": LaunchConfiguration("ground_truth_frame"),
         }.items(),
     )
 
@@ -76,5 +84,6 @@ def generate_launch_description():
         motion_profile_arg,
         motion_bias_arg,
         use_sim_time_arg,
+        ground_truth_frame_arg,
         include_sim,
     ])

--- a/yahboom_rosmaster_description/test/robot_description_contract_test.py
+++ b/yahboom_rosmaster_description/test/robot_description_contract_test.py
@@ -12,10 +12,10 @@ ROBOT_XACRO = (
     PACKAGE_DIR / "urdf" / "robots" / "rosmaster_x3.urdf.xacro"
 )
 WHEEL_ORIGINS = {
-    "front_left": (0.08, 0.0745, -0.0325),
-    "front_right": (0.08, -0.0745, -0.0325),
-    "back_left": (-0.08, 0.0745, -0.0325),
-    "back_right": (-0.08, -0.0745, -0.0325),
+    "front_left": (0.08, 0.0845, -0.0325),
+    "front_right": (0.08, -0.0845, -0.0325),
+    "back_left": (-0.08, 0.0845, -0.0325),
+    "back_right": (-0.08, -0.0845, -0.0325),
 }
 MESHES = {
     "base_link": "rosmaster_base.obj",
@@ -28,10 +28,10 @@ MESHES = {
 }
 VISUAL_ORIGINS = {
     "base_link": (0.0, 0.0, 0.0),
-    "front_left_wheel_link": (0.0, 0.01, 0.0),
-    "front_right_wheel_link": (0.0, -0.01, 0.0),
-    "back_left_wheel_link": (0.0, 0.01, 0.0),
-    "back_right_wheel_link": (0.0, -0.01, 0.0),
+    "front_left_wheel_link": (0.0, 0.0, 0.0),
+    "front_right_wheel_link": (0.0, 0.0, 0.0),
+    "back_left_wheel_link": (0.0, 0.0, 0.0),
+    "back_right_wheel_link": (0.0, 0.0, 0.0),
     "cam_1_link": (0.0, 0.0, 0.0),
     "laser_link": (0.0, 0.0, 0.0),
 }
@@ -158,7 +158,7 @@ class TestRobotDescriptionContract(unittest.TestCase):
                     self.assertEqual(joint.get("type"), wheel_type)
                     self.assertEqual(joint.find("axis").get("xyz"), "0 1 0")
 
-    def test_wheel_joint_contract_is_unchanged(self):
+    def test_wheel_joints_match_real_robot_geometry(self):
         for backend, robot in self.robots.items():
             for side, expected in WHEEL_ORIGINS.items():
                 with self.subTest(backend=backend, wheel=side):

--- a/yahboom_rosmaster_description/urdf/mech/mecanum_wheel.urdf.xacro
+++ b/yahboom_rosmaster_description/urdf/mech/mecanum_wheel.urdf.xacro
@@ -24,7 +24,6 @@
   <xacro:property name="wheel_width"     value="0.03040" />
   <xacro:property name="wheel_mass"      value="0.05"    />
   <xacro:property name="wheel_xoff"      value="0.08"    />
-  <xacro:property name="wheel_yoff"      value="-0.01"   />
 
   <xacro:macro name="mecanum_wheel" params="
     prefix
@@ -40,10 +39,9 @@
     joint_type:=continuous">
     <link name="${prefix}${side}_wheel_link">
       <visual>
-        <!-- Keep the established joint and collision position. Moving the
-             visual 10 mm along its rotation axis matches the assembled CAD
-             without changing contact geometry or drivetrain behavior. -->
-        <origin xyz="0 ${-y_reflect*wheel_yoff} 0" rpy="0 0 0"/>
+        <!-- The generated mesh is link-local; no additional visual offset is
+             needed once the joint uses the measured lateral wheel centre. -->
+        <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
           <mesh filename="file://$(find yahboom_rosmaster_description)/meshes/rosmaster_x3/cad_visual/${side}_wheel.obj"/>
         </geometry>
@@ -79,7 +77,7 @@
       <axis xyz="0 1 0"/>
       <parent link="${prefix}base_link"/>
       <child  link="${prefix}${side}_wheel_link"/>
-      <origin xyz="${x_reflect*wheel_xoff} ${y_reflect*(wheel_separation/2+wheel_yoff)} ${-wheel_radius}"
+      <origin xyz="${x_reflect*wheel_xoff} ${y_reflect*wheel_separation/2} ${-wheel_radius}"
               rpy="0 0 0"/>
       <dynamics damping="0.1" friction="0.0"/>
     </joint>

--- a/yahboom_rosmaster_gazebo/CMakeLists.txt
+++ b/yahboom_rosmaster_gazebo/CMakeLists.txt
@@ -18,6 +18,7 @@ install(
   PROGRAMS
     scripts/base_feedback_probe.py
     scripts/depth_geometry_probe.py
+    scripts/ground_truth_display_probe.py
     scripts/ground_truth_contract_probe.py
     scripts/imu_motion_probe.py
     scripts/lidar_geometry_probe.py
@@ -30,6 +31,11 @@ install(
     scripts/calculated_odometry.py
     scripts/ground_truth_tf.py
     scripts/pointcloud_frame_relay.py
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(
+  FILES scripts/ground_truth_alignment.py
   DESTINATION lib/${PROJECT_NAME}
 )
 
@@ -48,6 +54,10 @@ if(BUILD_TESTING)
   add_test(
     NAME motion_profile_contract
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/motion_profile_contract_test.py
+  )
+  add_test(
+    NAME ground_truth_alignment_math
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/ground_truth_alignment_test.py
   )
   add_launch_test(
     test/sensor_contract.launch.py
@@ -77,6 +87,11 @@ if(BUILD_TESTING)
     TIMEOUT 90
   )
   add_launch_test(
+    test/ground_truth_display.launch.py
+    TARGET ground_truth_display
+    TIMEOUT 30
+  )
+  add_launch_test(
     test/motion_profile_divergence.launch.py
     TARGET motion_profile_divergence_ideal
     TIMEOUT 100
@@ -87,6 +102,17 @@ if(BUILD_TESTING)
     TARGET motion_profile_divergence_stress
     TIMEOUT 100
     ARGS "motion_profile:=stress" "min_error:=0.003" "max_error:=0.030"
+  )
+  add_launch_test(
+    test/motion_profile_divergence.launch.py
+    TARGET motion_profile_yaw_ideal
+    TIMEOUT 100
+    ARGS
+      "motion_profile:=ideal"
+      "motion:=yaw"
+      "command_speed:=0.4"
+      "meaningful_yaw:=0.8"
+      "max_yaw_error:=0.005"
   )
   add_launch_test(
     test/lidar_geometry.launch.py

--- a/yahboom_rosmaster_gazebo/doc/deferred_simulator_changes.md
+++ b/yahboom_rosmaster_gazebo/doc/deferred_simulator_changes.md
@@ -1,23 +1,26 @@
 # Deferred simulator changes
 
-The Donatello CAD migration is intentionally visual-only. The ideas below were
-encountered while integrating and diagnosing the model, but each changes
-simulator behavior or architecture and should be evaluated independently.
+The original Donatello CAD migration was intentionally visual-only. The ideas
+below were encountered while integrating and diagnosing the model; each is
+evaluated independently, and accepted follow-ups are marked as implemented.
 
-## Correct physical wheel centres
+## Correct physical wheel centres (implemented)
 
-The drive plugin uses a `0.169 m` wheel separation, while the existing wheel
-joints and collision spheres are separated by `0.149 m`. Moving the joints from
-`y = +/-0.0745 m` to `y = +/-0.0845 m` would make the physical model agree with
-the plugin and assembled CAD.
+The physical robot description places its wheel axes at `x = +/-0.08 m` and
+approximately `y = +/-0.0845 m`: a `0.160 m` wheelbase and `0.169 m` wheel
+separation. The simulator previously subtracted a `0.01 m` lateral offset,
+leaving its joints and collision spheres only `0.149 m` apart even though the
+drive plugin and wheel-state odometry both used `0.169 m`.
 
-- Potential benefit: consistent wheel geometry, contact points, and kinematics.
-- Risk: changes existing physics, odometry behavior, and tuned motion tests.
-- Evaluate with: forward/reverse/strafe/rotation motion profiles, wheel odometry
-  divergence, and collision/contact inspection.
+The obsolete offset has been removed. Joints, collision spheres, and wheel
+inertias now use `y = +/-0.0845 m`, making contact geometry and rotational
+kinematics consistent with the real robot, drive plugin, and odometry model.
 
-For the visual migration, only the wheel meshes are shifted outward along their
-rotation axes. Joint and collision positions remain unchanged.
+The equal-and-opposite visual offsets were removed at the same time, so the CAD
+wheel meshes remain in their established rendered positions. The description
+contract protects the corrected joint origins and link-local visual origins. A
+headless ideal-profile yaw regression compares wheel odometry with raw ground
+truth after a meaningful turn.
 
 ## Controller-free joint-state path
 
@@ -114,7 +117,7 @@ remain in the package while the new model is being validated.
 
 ## Broader description contracts
 
-A focused test should protect unchanged links, joints, sensor frames,
-collisions, inertia, plugins, and installed visual assets. Renderer masks,
-alternative state sources, and corrected physics should be added to the
-contract only when those changes are separately accepted.
+A focused test protects unchanged links, joints, sensor frames, collisions,
+inertia, plugins, and installed visual assets. It also protects the accepted
+wheel-centre correction. Renderer masks and alternative state sources should
+be added to the contract only when those changes are separately accepted.

--- a/yahboom_rosmaster_gazebo/doc/ground_truth.md
+++ b/yahboom_rosmaster_gazebo/doc/ground_truth.md
@@ -1,0 +1,67 @@
+# Ground truth and localization frames
+
+## Raw measurement contract
+
+`/ground_truth/odom` is the Gazebo model pose expressed as
+`world -> base_footprint`. It is timestamped in simulation time and remains a
+measurement-only topic for evaluation, bags, and tests. Gazebo's pose output is
+not bridged into the robot TF tree, and no robot-facing component should use
+ground truth for navigation or state estimation.
+
+The robot estimate remains independent:
+
+- `/odom` and `odom -> base_footprint` come from wheel-state odometry;
+- a localization or SLAM system may publish `map -> odom`;
+- `/calc_odom` is only a command-integrated reference.
+
+## RViz diagnostic frame
+
+`ground_truth_tf.py` publishes the separate `ground_truth_base` frame for
+visual comparison. It does not reuse the raw world coordinates as odom
+coordinates. Instead, when synchronized wheel odometry and ground truth first
+become available, it captures the fixed alignment
+
+```text
+odom_T_world = odom_T_base(initial) * inverse(world_T_base(initial))
+```
+
+This makes nonzero Gazebo spawn poses safe and preserves subsequent physical
+divergence between wheel odometry and truth.
+
+The default `ground_truth_frame:=auto` mode initially publishes
+`odom -> ground_truth_base`. If a `map -> odom` transform later appears, the
+helper captures it once:
+
+```text
+map_T_world = map_T_odom(first) * odom_T_base(first)
+              * inverse(world_T_base(first))
+```
+
+It then publishes `map -> ground_truth_base` using that fixed alignment. Later
+SLAM corrections to `map -> odom` move the estimated robot but do not move
+ground truth. Using a synchronized robot pose here also handles SLAM starting
+after the robot has already moved. This is the intended comparison.
+
+Use `ground_truth_frame:=odom` to keep the diagnostic frame in odom even if a
+map appears. Use `ground_truth_frame:=map` to wait for map rather than publish
+the initial odom form. Another connected localization frame can also be named
+explicitly.
+
+Because the automatic mode switches the diagnostic child's parent once when a
+map first appears, it is for visualization and evaluation only. If a SLAM
+process is deliberately restarted with a new map coordinate system, restart
+the helper as well; an ordinary ongoing `map -> odom` correction must not cause
+realignment.
+
+## Regression coverage
+
+The ground-truth tests protect three independent properties:
+
+- the raw topic remains `world -> base_footprint`, has one publisher, uses
+  simulation timestamps, and never claims the robot's TF frames;
+- a nonzero world spawn aligns with the initial odometry origin;
+- after the first synthetic `map -> odom` alignment, a later large SLAM
+  correction does not move the truth frame, while new Gazebo motion still does.
+
+The synthetic map test does not replace an end-to-end run with the challenge's
+SLAM package. That integration run remains a follow-up check.

--- a/yahboom_rosmaster_gazebo/doc/motion_profiles.md
+++ b/yahboom_rosmaster_gazebo/doc/motion_profiles.md
@@ -6,8 +6,10 @@ The simulator exposes two independent pose sources:
   joint positions. It owns `odom -> base_footprint` on TF.
 - `/ground_truth/odom` is the Gazebo model's actual world pose, published as
   `nav_msgs/msg/Odometry` at 50 Hz with simulation timestamps. It is for tests,
-  analysis, and bags only; it does not publish TF and must not be used by the
-  robot-facing state estimate.
+  analysis, and bags only; it does not claim robot TF and must not be used by
+  the robot-facing state estimate. The independent `ground_truth_tf.py` helper
+  publishes only a frame-aligned `ground_truth_base` visualization. Its
+  world/odom/map contract is documented in [ground_truth.md](ground_truth.md).
 
 ## Selecting a profile
 

--- a/yahboom_rosmaster_gazebo/launch/rosmaster_gazebo_fortress.launch.py
+++ b/yahboom_rosmaster_gazebo/launch/rosmaster_gazebo_fortress.launch.py
@@ -337,6 +337,14 @@ def generate_launch_description():
             "Wheel-contact profile: stress is deterministic and uncalibrated; "
             "ideal preserves the zero-slip baseline"),
     )
+    declare_ground_truth_frame = DeclareLaunchArgument(
+        "ground_truth_frame",
+        default_value="auto",
+        description=(
+            "Diagnostic ground-truth display frame. 'auto' starts in odom and "
+            "captures a fixed map alignment if map->odom appears; use 'odom' "
+            "to disable the automatic SLAM switch"),
+    )
     headless = LaunchConfiguration("headless")
     gui = LaunchConfiguration("gui")
 
@@ -472,6 +480,10 @@ def generate_launch_description():
         package="yahboom_rosmaster_gazebo",
         executable="ground_truth_tf.py",
         output="screen",
+        parameters=[{
+            "use_sim_time": LaunchConfiguration("use_sim_time"),
+            "frame_id": LaunchConfiguration("ground_truth_frame"),
+        }],
     )
 
     motion_bias = LaunchConfiguration("motion_bias")
@@ -495,6 +507,7 @@ def generate_launch_description():
         declare_use_ros2_control,
         declare_motion_bias,
         declare_motion_profile,
+        declare_ground_truth_frame,
         # Force X11/XWayland for Gazebo GUI — prevents white window on Wayland + AMD GPU.
         # macOS has no xcb platform plugin; setting it there breaks every Qt app,
         # RViz included.

--- a/yahboom_rosmaster_gazebo/scripts/ground_truth_alignment.py
+++ b/yahboom_rosmaster_gazebo/scripts/ground_truth_alignment.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Small rigid-transform helpers for ground-truth frame alignment."""
+
+import math
+from typing import NamedTuple
+
+
+class RigidTransform(NamedTuple):
+    """Translation and quaternion for one parent-to-child transform."""
+
+    translation: tuple
+    rotation: tuple
+
+
+def normalize_quaternion(quaternion):
+    """Return a finite unit quaternion in ROS x/y/z/w order."""
+    norm = math.sqrt(sum(value * value for value in quaternion))
+    if not math.isfinite(norm) or norm < 1e-12:
+        raise ValueError("quaternion must be finite and non-zero")
+    return tuple(value / norm for value in quaternion)
+
+
+def multiply_quaternions(left, right):
+    """Compose two ROS-order quaternions."""
+    lx, ly, lz, lw = normalize_quaternion(left)
+    rx, ry, rz, rw = normalize_quaternion(right)
+    return normalize_quaternion((
+        lw * rx + lx * rw + ly * rz - lz * ry,
+        lw * ry - lx * rz + ly * rw + lz * rx,
+        lw * rz + lx * ry - ly * rx + lz * rw,
+        lw * rw - lx * rx - ly * ry - lz * rz,
+    ))
+
+
+def rotate_vector(quaternion, vector):
+    """Rotate a three-vector by a ROS-order quaternion."""
+    qx, qy, qz, qw = normalize_quaternion(quaternion)
+    vx, vy, vz = vector
+    # Equivalent to q * (v, 0) * inverse(q), expanded to avoid allocating
+    # temporary quaternions whose vector form is intentionally non-unit.
+    tx = 2.0 * (qy * vz - qz * vy)
+    ty = 2.0 * (qz * vx - qx * vz)
+    tz = 2.0 * (qx * vy - qy * vx)
+    return (
+        vx + qw * tx + qy * tz - qz * ty,
+        vy + qw * ty + qz * tx - qx * tz,
+        vz + qw * tz + qx * ty - qy * tx,
+    )
+
+
+def compose(parent_to_middle, middle_to_child):
+    """Return parent-to-child from parent-to-middle and middle-to-child."""
+    rotated = rotate_vector(
+        parent_to_middle.rotation, middle_to_child.translation)
+    return RigidTransform(
+        tuple(
+            parent + child
+            for parent, child in zip(parent_to_middle.translation, rotated)
+        ),
+        multiply_quaternions(
+            parent_to_middle.rotation, middle_to_child.rotation),
+    )
+
+
+def inverse(transform):
+    """Return the inverse of a rigid transform."""
+    qx, qy, qz, qw = normalize_quaternion(transform.rotation)
+    inverse_rotation = (-qx, -qy, -qz, qw)
+    inverse_translation = rotate_vector(
+        inverse_rotation,
+        tuple(-value for value in transform.translation),
+    )
+    return RigidTransform(inverse_translation, inverse_rotation)
+
+
+def yaw_quaternion(yaw):
+    """Return a quaternion for a pure yaw rotation (mainly for tests)."""
+    return (0.0, 0.0, math.sin(yaw * 0.5), math.cos(yaw * 0.5))

--- a/yahboom_rosmaster_gazebo/scripts/ground_truth_display_probe.py
+++ b/yahboom_rosmaster_gazebo/scripts/ground_truth_display_probe.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Exercise ground-truth display alignment with synthetic TF changes."""
+
+import math
+import sys
+import time
+
+from geometry_msgs.msg import TransformStamped
+from nav_msgs.msg import Odometry
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy
+from tf2_msgs.msg import TFMessage
+from tf2_ros import TransformBroadcaster
+
+from ground_truth_alignment import RigidTransform, compose, inverse, yaw_quaternion
+
+
+def quaternion_distance(left, right):
+    """Return sign-insensitive Euclidean quaternion distance."""
+    direct = math.sqrt(sum((a - b) ** 2 for a, b in zip(left, right)))
+    negated = math.sqrt(sum((a + b) ** 2 for a, b in zip(left, right)))
+    return min(direct, negated)
+
+
+def close_transform(actual, expected, tolerance=1e-5):
+    """Return whether translation and rotation agree within tolerance."""
+    return (
+        math.dist(actual.translation, expected.translation) <= tolerance
+        and quaternion_distance(actual.rotation, expected.rotation) <= tolerance
+    )
+
+
+class GroundTruthDisplayProbe(Node):
+    """Publish a nonidentity spawn and a changing synthetic map correction."""
+
+    def __init__(self):
+        super().__init__("ground_truth_display_probe")
+        self.truth_publisher = self.create_publisher(
+            Odometry, "/ground_truth/odom", 10)
+        self.tf_broadcaster = TransformBroadcaster(self)
+        qos = QoSProfile(depth=100, reliability=ReliabilityPolicy.BEST_EFFORT)
+        self.create_subscription(TFMessage, "/tf", self.capture_tf, qos)
+
+        self.world_from_base_initial = RigidTransform(
+            (7.0, 4.0, 0.2), yaw_quaternion(-0.6))
+        self.odom_from_base = RigidTransform(
+            (1.0, -2.0, 0.1), yaw_quaternion(0.25))
+        self.world_from_base_at_map_start = compose(
+            self.world_from_base_initial,
+            RigidTransform((0.4, 0.1, 0.0), yaw_quaternion(0.12)),
+        )
+        self.odom_from_base_at_map_start = compose(
+            self.odom_from_base,
+            RigidTransform((0.45, 0.08, 0.0), yaw_quaternion(0.14)),
+        )
+        self.first_map_from_odom = RigidTransform(
+            (3.0, 1.0, 0.0), yaw_quaternion(0.4))
+        self.changed_map_from_odom = RigidTransform(
+            (30.0, -10.0, 0.0), yaw_quaternion(-1.0))
+        self.world_from_base_later = compose(
+            self.world_from_base_at_map_start,
+            RigidTransform((0.6, -0.2, 0.0), yaw_quaternion(0.15)),
+        )
+        self.fixed_map_from_world = compose(
+            compose(self.first_map_from_odom, self.odom_from_base_at_map_start),
+            inverse(self.world_from_base_at_map_start),
+        )
+
+        self.phase = "odom"
+        self.phase_started = time.monotonic()
+        self.matches = 0
+        self.mismatches = 0
+        self.done = False
+        self.error = None
+        self.create_timer(0.02, self.publish_inputs)
+
+    @staticmethod
+    def to_message(parent, child, value, stamp):
+        """Convert a transform value into a stamped ROS transform."""
+        message = TransformStamped()
+        message.header.stamp = stamp
+        message.header.frame_id = parent
+        message.child_frame_id = child
+        message.transform.translation.x = value.translation[0]
+        message.transform.translation.y = value.translation[1]
+        message.transform.translation.z = value.translation[2]
+        message.transform.rotation.x = value.rotation[0]
+        message.transform.rotation.y = value.rotation[1]
+        message.transform.rotation.z = value.rotation[2]
+        message.transform.rotation.w = value.rotation[3]
+        return message
+
+    @staticmethod
+    def from_message(message):
+        """Convert a ROS transform into a transform value."""
+        value = message.transform
+        return RigidTransform(
+            (value.translation.x, value.translation.y, value.translation.z),
+            (value.rotation.x, value.rotation.y, value.rotation.z, value.rotation.w),
+        )
+
+    def publish_inputs(self):
+        """Publish synchronized truth, odometry TF, and phased SLAM TF."""
+        if self.done:
+            return
+        if time.monotonic() - self.phase_started > 6.0:
+            self.fail(f"timed out in {self.phase!r} phase")
+            return
+
+        stamp = self.get_clock().now().to_msg()
+        odom_from_base = (
+            self.odom_from_base
+            if self.phase == "odom"
+            else self.odom_from_base_at_map_start
+        )
+        transforms = [self.to_message(
+            "odom", "base_footprint", odom_from_base, stamp)]
+        if self.phase == "map_initial":
+            transforms.append(self.to_message(
+                "map", "odom", self.first_map_from_odom, stamp))
+        elif self.phase == "map_changed":
+            transforms.append(self.to_message(
+                "map", "odom", self.changed_map_from_odom, stamp))
+        self.tf_broadcaster.sendTransform(transforms)
+
+        if self.phase == "odom":
+            world_from_base = self.world_from_base_initial
+        elif self.phase == "map_initial":
+            world_from_base = self.world_from_base_at_map_start
+        else:
+            world_from_base = self.world_from_base_later
+        truth = Odometry()
+        truth.header.stamp = stamp
+        truth.header.frame_id = "world"
+        truth.child_frame_id = "base_footprint"
+        truth.pose.pose.position.x = world_from_base.translation[0]
+        truth.pose.pose.position.y = world_from_base.translation[1]
+        truth.pose.pose.position.z = world_from_base.translation[2]
+        truth.pose.pose.orientation.x = world_from_base.rotation[0]
+        truth.pose.pose.orientation.y = world_from_base.rotation[1]
+        truth.pose.pose.orientation.z = world_from_base.rotation[2]
+        truth.pose.pose.orientation.w = world_from_base.rotation[3]
+        self.truth_publisher.publish(truth)
+
+    def capture_tf(self, message):
+        """Validate the diagnostic child in each alignment phase."""
+        for transform in message.transforms:
+            if transform.child_frame_id != "ground_truth_base":
+                continue
+            if self.phase == "odom" and transform.header.frame_id == "odom":
+                self.record(self.from_message(transform), self.odom_from_base)
+            elif (
+                    self.phase == "map_initial"
+                    and transform.header.frame_id == "map"):
+                self.record(
+                    self.from_message(transform),
+                    compose(
+                        self.first_map_from_odom,
+                        self.odom_from_base_at_map_start,
+                    ),
+                )
+            elif (
+                    self.phase == "map_changed"
+                    and transform.header.frame_id == "map"):
+                self.record(
+                    self.from_message(transform),
+                    compose(self.fixed_map_from_world, self.world_from_base_later),
+                )
+
+    def record(self, actual, expected):
+        """Advance after repeated matches and fail on persistent disagreement."""
+        if close_transform(actual, expected):
+            self.matches += 1
+        else:
+            self.mismatches += 1
+        if self.mismatches >= 10:
+            self.fail(
+                f"{self.phase} transform disagreed with fixed alignment "
+                f"{self.mismatches} times")
+            return
+        required = 5 if self.phase != "map_changed" else 10
+        if self.matches < required:
+            return
+        if self.phase == "odom":
+            self.advance("map_initial")
+        elif self.phase == "map_initial":
+            self.advance("map_changed")
+        else:
+            self.done = True
+            self.get_logger().info(
+                "Ground-truth display PASSED: nonzero spawn aligned and later "
+                "map->odom correction did not move truth")
+
+    def advance(self, phase):
+        """Begin the next probe phase."""
+        self.phase = phase
+        self.phase_started = time.monotonic()
+        self.matches = 0
+        self.mismatches = 0
+
+    def fail(self, reason):
+        """Stop the probe with a failure reason."""
+        self.error = reason
+        self.done = True
+        self.get_logger().error(reason)
+
+
+def main():
+    rclpy.init()
+    node = GroundTruthDisplayProbe()
+    try:
+        while rclpy.ok() and not node.done:
+            rclpy.spin_once(node, timeout_sec=0.1)
+        return 1 if node.error else 0
+    finally:
+        node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/yahboom_rosmaster_gazebo/scripts/ground_truth_tf.py
+++ b/yahboom_rosmaster_gazebo/scripts/ground_truth_tf.py
@@ -1,55 +1,295 @@
 #!/usr/bin/env python3
 """
-Broadcast the simulator's ground-truth pose as a TF frame.
+Broadcast a display-only, frame-aligned simulator ground-truth pose.
 
-/ground_truth/odom is measurement-only and deliberately outside the robot's own
-TF tree, so nothing can accidentally navigate on a perfect pose. Publishing it
-under a separate `ground_truth_base` frame keeps that separation while letting
-RViz show the true pose next to the estimated one, which is what makes odometry
-drift visible.
-
-This is a runtime node. The matching contract check lives in
-scripts/ground_truth_contract_probe.py, which must stay a probe: it validates
-and exits, whereas this runs for the life of the simulation.
+The raw `/ground_truth/odom` measurement remains `world -> base_footprint` and
+never enters the robot-facing TF tree. This node creates only the separate
+`ground_truth_base` diagnostic frame. It captures one fixed `odom <- world`
+alignment, then optionally one fixed `map <- world` alignment when SLAM appears.
+Later `map -> odom` corrections must not move the ground-truth frame.
 """
+
+from collections import deque
+import math
+import time
 
 import rclpy
 from geometry_msgs.msg import TransformStamped
 from nav_msgs.msg import Odometry
+from rclpy.duration import Duration
 from rclpy.node import Node
-from tf2_ros import TransformBroadcaster
+from rclpy.time import Time
+from tf2_ros import Buffer, TransformBroadcaster, TransformException, TransformListener
+
+from ground_truth_alignment import RigidTransform, compose, inverse
 
 
 class GroundTruthTf(Node):
-    """Republish ground-truth odometry as a transform."""
+    """Publish ground truth in a fixed diagnostic display frame."""
 
     def __init__(self):
         super().__init__("ground_truth_tf")
         self.declare_parameter("input_topic", "/ground_truth/odom")
-        self.declare_parameter("frame_id", "odom")
+        self.declare_parameter("frame_id", "auto")
         self.declare_parameter("child_frame_id", "ground_truth_base")
+        self.declare_parameter("world_frame_id", "world")
+        self.declare_parameter("odom_frame_id", "odom")
+        self.declare_parameter("base_frame_id", "base_footprint")
+        self.declare_parameter("map_frame_id", "map")
+        self.declare_parameter("alignment_timeout", 2.0)
 
-        self.frame_id = self.get_parameter("frame_id").value
+        self.frame_mode = self.get_parameter("frame_id").value
         self.child_frame_id = self.get_parameter("child_frame_id").value
+        self.world_frame_id = self.get_parameter("world_frame_id").value
+        self.odom_frame_id = self.get_parameter("odom_frame_id").value
+        self.base_frame_id = self.get_parameter("base_frame_id").value
+        self.map_frame_id = self.get_parameter("map_frame_id").value
+        self.alignment_timeout = float(
+            self.get_parameter("alignment_timeout").value)
         input_topic = self.get_parameter("input_topic").value
 
+        if not all((
+                self.frame_mode,
+                self.child_frame_id,
+                self.world_frame_id,
+                self.odom_frame_id,
+                self.base_frame_id,
+                self.map_frame_id)):
+            raise ValueError("ground-truth frame parameters must not be empty")
+        if self.alignment_timeout <= 0.0:
+            raise ValueError("alignment_timeout must be positive")
+
+        self.tf_buffer = Buffer()
+        self.tf_listener = TransformListener(self.tf_buffer, self)
         self.broadcaster = TransformBroadcaster(self)
+        self.pending_ground_truth = deque(maxlen=250)
+        self.recent_ground_truth = deque(maxlen=100)
+        self.odom_from_world = None
+        self.display_from_world = None
+        self.display_frame_id = None
+        self.last_input_error = 0.0
         self.create_subscription(Odometry, input_topic, self.odom_callback, 10)
+        self.create_timer(0.05, self.process_pending)
 
         self.get_logger().info(
-            f"Broadcasting {self.frame_id} -> {self.child_frame_id} from {input_topic}")
+            f"Aligning {input_topic} into frame mode {self.frame_mode!r} as "
+            f"{self.child_frame_id}")
+
+    @staticmethod
+    def normalized_frame(frame_id):
+        """Normalize a frame ID for comparisons without changing output."""
+        return frame_id.lstrip("/")
+
+    @staticmethod
+    def pose_transform(pose):
+        """Convert a geometry pose into a transform value."""
+        return RigidTransform(
+            (pose.position.x, pose.position.y, pose.position.z),
+            (
+                pose.orientation.x,
+                pose.orientation.y,
+                pose.orientation.z,
+                pose.orientation.w,
+            ),
+        )
+
+    @staticmethod
+    def message_transform(transform):
+        """Convert a geometry transform into a transform value."""
+        return RigidTransform(
+            (
+                transform.translation.x,
+                transform.translation.y,
+                transform.translation.z,
+            ),
+            (
+                transform.rotation.x,
+                transform.rotation.y,
+                transform.rotation.z,
+                transform.rotation.w,
+            ),
+        )
+
+    def valid_input_frames(self, message):
+        """Reject a source whose coordinates do not match the declared contract."""
+        valid = (
+            self.normalized_frame(message.header.frame_id)
+            == self.normalized_frame(self.world_frame_id)
+            and self.normalized_frame(message.child_frame_id)
+            == self.normalized_frame(self.base_frame_id)
+        )
+        if not valid and time.monotonic() - self.last_input_error >= 5.0:
+            self.last_input_error = time.monotonic()
+            self.get_logger().error(
+                "Ignoring ground truth with frames "
+                f"{message.header.frame_id!r} -> {message.child_frame_id!r}; "
+                f"expected {self.world_frame_id!r} -> {self.base_frame_id!r}")
+        return valid
 
     def odom_callback(self, message):
-        """Convert one ground-truth odometry message into a transform."""
+        """Queue or publish one raw Gazebo ground-truth measurement."""
+        if not self.valid_input_frames(message):
+            return
+        self.recent_ground_truth.append(message)
+        if self.odom_from_world is None:
+            self.pending_ground_truth.append((time.monotonic(), message))
+            self.process_pending()
+            return
+        self.maybe_select_localization_frame(message)
+        self.publish_ground_truth(message)
+
+    def lookup(self, target_frame, source_frame, stamp=None):
+        """Look up a transform, returning None while the TF data catches up."""
+        query_time = Time() if stamp is None else Time.from_msg(stamp)
+        try:
+            result = self.tf_buffer.lookup_transform(
+                target_frame,
+                source_frame,
+                query_time,
+                timeout=Duration(seconds=0.0),
+            )
+        except TransformException:
+            return None
+        return self.message_transform(result.transform)
+
+    def process_pending(self):
+        """Find a time-aligned odometry sample and establish the fixed origin."""
+        if self.odom_from_world is not None:
+            target_frame = self.requested_localization_frame()
+            if target_frame is None or self.display_frame_id == target_frame:
+                self.recent_ground_truth.clear()
+                return
+            if self.lookup(target_frame, self.odom_frame_id) is None:
+                return
+            for message in tuple(self.recent_ground_truth):
+                if self.maybe_select_localization_frame(message):
+                    self.recent_ground_truth.clear()
+                    break
+            return
+        if not self.pending_ground_truth:
+            return
+
+        now = time.monotonic()
+        for arrival, message in tuple(self.pending_ground_truth):
+            odom_from_base = self.lookup(
+                self.odom_frame_id,
+                self.base_frame_id,
+                message.header.stamp,
+            )
+            if odom_from_base is None:
+                continue
+
+            world_from_base = self.pose_transform(message.pose.pose)
+            try:
+                self.odom_from_world = compose(
+                    odom_from_base, inverse(world_from_base))
+            except ValueError as exception:
+                self.get_logger().error(
+                    f"Cannot align invalid ground-truth pose: {exception}")
+                self.pending_ground_truth.clear()
+                return
+
+            if self.frame_mode in ("auto", self.odom_frame_id):
+                self.display_frame_id = self.odom_frame_id
+                self.display_from_world = self.odom_from_world
+            self.get_logger().info(
+                f"Captured fixed {self.odom_frame_id} <- {self.world_frame_id} "
+                "ground-truth alignment")
+            self.maybe_select_localization_frame(message)
+
+            queued = [
+                queued_message
+                for queued_arrival, queued_message in self.pending_ground_truth
+                if queued_arrival >= arrival
+            ]
+            self.pending_ground_truth.clear()
+            for queued_message in queued:
+                self.publish_ground_truth(queued_message)
+            return
+
+        while (
+                self.pending_ground_truth
+                and now - self.pending_ground_truth[0][0] > self.alignment_timeout):
+            self.pending_ground_truth.popleft()
+        if not self.pending_ground_truth:
+            self.get_logger().warning(
+                f"Could not align ground truth: no synchronized "
+                f"{self.odom_frame_id} -> {self.base_frame_id} TF within "
+                f"{self.alignment_timeout:.1f}s")
+
+    def requested_localization_frame(self):
+        """Return the final localization frame requested by the mode."""
+        if self.frame_mode == "auto":
+            return self.map_frame_id
+        if self.frame_mode == self.odom_frame_id:
+            return None
+        return self.frame_mode
+
+    def maybe_select_localization_frame(self, ground_truth):
+        """Capture one fixed localization-to-world alignment when available."""
+        target_frame = self.requested_localization_frame()
+        if (
+                self.odom_from_world is None
+                or target_frame is None
+                or self.display_frame_id == target_frame):
+            return False
+
+        target_from_odom = self.lookup(
+            target_frame, self.odom_frame_id, ground_truth.header.stamp)
+        odom_from_base = self.lookup(
+            self.odom_frame_id,
+            self.base_frame_id,
+            ground_truth.header.stamp,
+        )
+        if target_from_odom is None or odom_from_base is None:
+            return False
+        world_from_base = self.pose_transform(ground_truth.pose.pose)
+        self.display_from_world = compose(
+            compose(target_from_odom, odom_from_base),
+            inverse(world_from_base),
+        )
+        previous_frame = self.display_frame_id
+        self.display_frame_id = target_frame
+        if previous_frame is None:
+            self.get_logger().info(
+                f"Captured fixed {target_frame} <- {self.world_frame_id} "
+                "ground-truth alignment")
+        else:
+            self.get_logger().info(
+                f"Ground-truth display switched from {previous_frame} to "
+                f"{target_frame}; later {target_frame} -> {self.odom_frame_id} "
+                "corrections will not move truth")
+        return True
+
+    def publish_ground_truth(self, message):
+        """Publish one aligned diagnostic transform without touching robot TF."""
+        if self.display_from_world is None or self.display_frame_id is None:
+            return
+        try:
+            display_from_base = compose(
+                self.display_from_world,
+                self.pose_transform(message.pose.pose),
+            )
+        except ValueError as exception:
+            self.get_logger().error(
+                f"Cannot publish invalid ground-truth pose: {exception}")
+            return
+
         transform = TransformStamped()
-        # Reuse the simulator's stamp so the transform stays on sim time.
         transform.header.stamp = message.header.stamp
-        transform.header.frame_id = self.frame_id
+        transform.header.frame_id = self.display_frame_id
         transform.child_frame_id = self.child_frame_id
-        transform.transform.translation.x = message.pose.pose.position.x
-        transform.transform.translation.y = message.pose.pose.position.y
-        transform.transform.translation.z = message.pose.pose.position.z
-        transform.transform.rotation = message.pose.pose.orientation
+        transform.transform.translation.x = display_from_base.translation[0]
+        transform.transform.translation.y = display_from_base.translation[1]
+        transform.transform.translation.z = display_from_base.translation[2]
+        transform.transform.rotation.x = display_from_base.rotation[0]
+        transform.transform.rotation.y = display_from_base.rotation[1]
+        transform.transform.rotation.z = display_from_base.rotation[2]
+        transform.transform.rotation.w = display_from_base.rotation[3]
+        if not all(math.isfinite(value) for value in (
+                *display_from_base.translation, *display_from_base.rotation)):
+            self.get_logger().error("Aligned ground truth contains non-finite values")
+            return
         self.broadcaster.sendTransform(transform)
 
 

--- a/yahboom_rosmaster_gazebo/scripts/motion_profile_divergence_probe.py
+++ b/yahboom_rosmaster_gazebo/scripts/motion_profile_divergence_probe.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Measure strafe divergence between wheel odometry and ground truth."""
+"""Measure planar divergence between wheel odometry and ground truth."""
 
 import math
 import sys
@@ -31,6 +31,19 @@ def quaternion_yaw(orientation):
     return math.atan2(sin_yaw, cos_yaw)
 
 
+def normalized_angle(angle):
+    """Wrap an angle to [-pi, pi]."""
+    return math.atan2(math.sin(angle), math.cos(angle))
+
+
+def relative_yaw(start, end):
+    """Return the wrapped planar rotation between two odometry poses."""
+    return normalized_angle(
+        quaternion_yaw(end.pose.pose.orientation)
+        - quaternion_yaw(start.pose.pose.orientation)
+    )
+
+
 def relative_translation(start, end):
     """Express an odometry position delta in its initial body coordinates."""
     dx = end.pose.pose.position.x - start.pose.pose.position.x
@@ -43,11 +56,12 @@ def relative_translation(start, end):
 
 
 class MotionProfileDivergenceProbe(Node):
-    """Command one repeatable strafe and evaluate its settled endpoint error."""
+    """Command one repeatable motion and evaluate its settled endpoint error."""
 
     def __init__(self):
         super().__init__("motion_profile_divergence_probe")
         self.declare_parameter("profile", "stress")
+        self.declare_parameter("motion", "strafe")
         self.declare_parameter("timeout", 40.0)
         self.declare_parameter("command_speed", 0.2)
         self.declare_parameter("command_duration", 3.0)
@@ -56,8 +70,11 @@ class MotionProfileDivergenceProbe(Node):
         self.declare_parameter("meaningful_motion", 0.3)
         self.declare_parameter("min_translation_error", 0.003)
         self.declare_parameter("max_translation_error", 0.030)
+        self.declare_parameter("meaningful_yaw", 0.8)
+        self.declare_parameter("max_yaw_error", 0.005)
 
         self.profile = str(self.get_parameter("profile").value)
+        self.motion = str(self.get_parameter("motion").value)
         self.timeout = float(self.get_parameter("timeout").value)
         self.command_speed = float(self.get_parameter("command_speed").value)
         self.command_duration = float(
@@ -72,6 +89,10 @@ class MotionProfileDivergenceProbe(Node):
             self.get_parameter("min_translation_error").value)
         self.max_translation_error = float(
             self.get_parameter("max_translation_error").value)
+        self.meaningful_yaw = float(
+            self.get_parameter("meaningful_yaw").value)
+        self.max_yaw_error = float(
+            self.get_parameter("max_yaw_error").value)
 
         self.clock_time = None
         self.odometry = None
@@ -155,6 +176,33 @@ class MotionProfileDivergenceProbe(Node):
     def evaluate(self, start_odom, start_truth, end_odom, end_truth):
         """Return errors and a compact result string for the completed motion."""
         errors = []
+        if self.motion == "yaw":
+            odom_yaw = relative_yaw(start_odom, end_odom)
+            truth_yaw = relative_yaw(start_truth, end_truth)
+            yaw_error = abs(normalized_angle(odom_yaw - truth_yaw))
+            if not all(math.isfinite(value) for value in (
+                    odom_yaw, truth_yaw, yaw_error)):
+                errors.append("motion result contains non-finite values")
+            if abs(odom_yaw) < self.meaningful_yaw:
+                errors.append(
+                    f"wheel odometry rotated only {odom_yaw:.6f}rad; expected "
+                    f"at least {self.meaningful_yaw:.3f}rad")
+            if abs(truth_yaw) < self.meaningful_yaw:
+                errors.append(
+                    f"ground truth rotated only {truth_yaw:.6f}rad; expected "
+                    f"at least {self.meaningful_yaw:.3f}rad")
+            if yaw_error > self.max_yaw_error:
+                errors.append(
+                    f"yaw error {yaw_error:.6f}rad exceeds "
+                    f"{self.max_yaw_error:.6f}rad")
+            summary = (
+                f"profile={self.profile}, motion=yaw, "
+                f"odom_delta={odom_yaw:.6f}rad, "
+                f"truth_delta={truth_yaw:.6f}rad, "
+                f"yaw_error={yaw_error:.6f}rad"
+            )
+            return errors, summary
+
         odom_delta = relative_translation(start_odom, end_odom)
         truth_delta = relative_translation(start_truth, end_truth)
         odom_distance = math.hypot(*odom_delta)
@@ -185,7 +233,7 @@ class MotionProfileDivergenceProbe(Node):
                 f"{self.max_translation_error:.6f}]m")
 
         summary = (
-            f"profile={self.profile}, "
+            f"profile={self.profile}, motion=strafe, "
             f"odom_delta=({odom_delta[0]:.6f}, {odom_delta[1]:.6f})m, "
             f"truth_delta=({truth_delta[0]:.6f}, {truth_delta[1]:.6f})m, "
             f"translation_error={translation_error:.6f}m"
@@ -197,8 +245,18 @@ def main():
     rclpy.init()
     node = MotionProfileDivergenceProbe()
     stop = Twist()
-    strafe = Twist()
-    strafe.linear.y = node.command_speed
+    command = Twist()
+    if node.motion == "strafe":
+        command.linear.y = node.command_speed
+    elif node.motion == "yaw":
+        command.angular.z = node.command_speed
+    else:
+        node.get_logger().error(
+            f"Motion-profile divergence FAILED: unsupported motion "
+            f"{node.motion!r}")
+        node.destroy_node()
+        rclpy.shutdown()
+        return 1
     wall_deadline = time.monotonic() + node.timeout
 
     try:
@@ -224,9 +282,10 @@ def main():
         start_truth = node.ground_truth
 
         if not node.publish_until_sim_time(
-                strafe, node.command_duration, wall_deadline):
+                command, node.command_duration, wall_deadline):
             node.get_logger().error(
-                "Motion-profile divergence FAILED: strafe command timed out")
+                f"Motion-profile divergence FAILED: {node.motion} command "
+                "timed out")
             return 1
         if not node.publish_until_sim_time(
                 stop, node.final_settle_duration, wall_deadline):

--- a/yahboom_rosmaster_gazebo/test/ground_truth_alignment_test.py
+++ b/yahboom_rosmaster_gazebo/test/ground_truth_alignment_test.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Unit tests for fixed world/odom/map ground-truth alignment."""
+
+import math
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from ground_truth_alignment import (  # noqa: E402
+    RigidTransform,
+    compose,
+    inverse,
+    yaw_quaternion,
+)
+
+
+def quaternion_distance(left, right):
+    """Return sign-insensitive Euclidean quaternion distance."""
+    direct = math.sqrt(sum((a - b) ** 2 for a, b in zip(left, right)))
+    negated = math.sqrt(sum((a + b) ** 2 for a, b in zip(left, right)))
+    return min(direct, negated)
+
+
+class GroundTruthAlignmentTest(unittest.TestCase):
+    """Protect the alignment math independently of ROS runtime timing."""
+
+    def assert_transform_close(self, actual, expected, tolerance=1e-10):
+        for actual_value, expected_value in zip(
+                actual.translation, expected.translation):
+            self.assertAlmostEqual(actual_value, expected_value, delta=tolerance)
+        self.assertLessEqual(
+            quaternion_distance(actual.rotation, expected.rotation), tolerance)
+
+    def test_inverse_round_trip(self):
+        value = RigidTransform((3.0, -2.0, 0.4), yaw_quaternion(0.73))
+        identity = compose(value, inverse(value))
+        self.assert_transform_close(
+            identity,
+            RigidTransform((0.0, 0.0, 0.0), (0.0, 0.0, 0.0, 1.0)),
+        )
+
+    def test_nonzero_spawn_aligns_truth_with_initial_odometry(self):
+        world_from_base = RigidTransform(
+            (8.0, -4.0, 0.0325), yaw_quaternion(-0.6))
+        odom_from_base = RigidTransform(
+            (0.0, 0.0, 0.0), yaw_quaternion(0.0))
+        odom_from_world = compose(
+            odom_from_base, inverse(world_from_base))
+
+        aligned_truth = compose(odom_from_world, world_from_base)
+        self.assert_transform_close(aligned_truth, odom_from_base)
+
+    def test_map_alignment_is_frozen_after_first_slam_transform(self):
+        world_from_base_initial = RigidTransform(
+            (5.0, 2.0, 0.1), yaw_quaternion(-0.4))
+        odom_from_base_initial = RigidTransform(
+            (0.3, -0.2, 0.0), yaw_quaternion(0.1))
+        world_from_base_at_slam_start = compose(
+            world_from_base_initial,
+            RigidTransform((0.5, 0.1, 0.0), yaw_quaternion(0.15)),
+        )
+        odom_from_base_at_slam_start = compose(
+            odom_from_base_initial,
+            RigidTransform((0.54, 0.08, 0.0), yaw_quaternion(0.17)),
+        )
+
+        first_map_from_odom = RigidTransform(
+            (2.0, -1.0, 0.0), yaw_quaternion(0.25))
+        fixed_map_from_world = compose(
+            compose(first_map_from_odom, odom_from_base_at_slam_start),
+            inverse(world_from_base_at_slam_start),
+        )
+
+        world_from_base_later = compose(
+            world_from_base_initial,
+            RigidTransform((0.8, -0.1, 0.0), yaw_quaternion(0.2)),
+        )
+        expected_truth = compose(fixed_map_from_world, world_from_base_later)
+
+        corrected_map_from_odom = RigidTransform(
+            (20.0, 7.0, 0.0), yaw_quaternion(-1.0))
+        incorrectly_recomputed = compose(
+            compose(corrected_map_from_odom, odom_from_base_at_slam_start),
+            compose(inverse(world_from_base_at_slam_start), world_from_base_later),
+        )
+
+        self.assert_transform_close(
+            compose(fixed_map_from_world, world_from_base_later),
+            expected_truth,
+        )
+        self.assertGreater(
+            math.dist(
+                incorrectly_recomputed.translation,
+                expected_truth.translation,
+            ),
+            1.0,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/yahboom_rosmaster_gazebo/test/ground_truth_display.launch.py
+++ b/yahboom_rosmaster_gazebo/test/ground_truth_display.launch.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Launch-test fixed ground-truth display alignment without Gazebo."""
+
+import os
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import SetEnvironmentVariable, TimerAction
+from launch_ros.actions import Node
+import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+import pytest
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    helper = Node(
+        package="yahboom_rosmaster_gazebo",
+        executable="ground_truth_tf.py",
+        parameters=[{
+            "frame_id": "auto",
+            "alignment_timeout": 1.0,
+        }],
+        output="screen",
+    )
+    probe = Node(
+        package="yahboom_rosmaster_gazebo",
+        executable="ground_truth_display_probe.py",
+        output="screen",
+    )
+    return LaunchDescription([
+        SetEnvironmentVariable(
+            "ROS_DOMAIN_ID", str(10 + os.getpid() % 211)),
+        helper,
+        TimerAction(period=0.5, actions=[probe]),
+        launch_testing.actions.ReadyToTest(),
+    ]), {"probe": probe}
+
+
+class TestGroundTruthDisplay(unittest.TestCase):
+    """Require the synthetic alignment probe to pass."""
+
+    def test_probe_passes(self, proc_info, probe):
+        proc_info.assertWaitForStartup(probe, timeout=10)
+        proc_info.assertWaitForShutdown(probe, timeout=20)
+        launch_testing.asserts.assertExitCodes(proc_info, process=probe)
+
+
+@launch_testing.post_shutdown_test()
+class TestCleanShutdown(unittest.TestCase):
+    """Require every launched process to exit cleanly."""
+
+    def test_all_processes_exit_cleanly(self, proc_info):
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/yahboom_rosmaster_gazebo/test/motion_profile_divergence.launch.py
+++ b/yahboom_rosmaster_gazebo/test/motion_profile_divergence.launch.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Launch-test profile-specific odometry divergence during a strafe."""
+"""Launch-test profile-specific odometry divergence during planar motion."""
 
 import os
 import unittest
@@ -26,8 +26,12 @@ import pytest
 def generate_test_description():
     package_share = get_package_share_directory("yahboom_rosmaster_gazebo")
     motion_profile = LaunchConfiguration("motion_profile")
+    motion = LaunchConfiguration("motion")
+    command_speed = LaunchConfiguration("command_speed")
     min_error = LaunchConfiguration("min_error")
     max_error = LaunchConfiguration("max_error")
+    meaningful_yaw = LaunchConfiguration("meaningful_yaw")
+    max_yaw_error = LaunchConfiguration("max_yaw_error")
     simulator = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(
@@ -42,6 +46,9 @@ def generate_test_description():
             "use_sim_time": "true",
             "world": os.path.join(package_share, "worlds", "empty.world"),
             "motion_profile": motion_profile,
+            # Motion/odometry tests do not consume rendering sensors. Omitting
+            # them also avoids renderer-specific shutdown behavior.
+            "render_sensors": "false",
             # This test pins the divergence between commanded and achieved
             # trajectory to a numeric window, so the only perturbation must be
             # the wheel-contact profile. The /cmd_vel motion bias is resampled
@@ -54,8 +61,10 @@ def generate_test_description():
         executable="motion_profile_divergence_probe.py",
         parameters=[{
             "profile": ParameterValue(motion_profile, value_type=str),
+            "motion": ParameterValue(motion, value_type=str),
             "timeout": 40.0,
-            "command_speed": 0.2,
+            "command_speed": ParameterValue(
+                command_speed, value_type=float),
             "command_duration": 3.0,
             "initial_settle_duration": 1.0,
             "final_settle_duration": 1.0,
@@ -64,14 +73,22 @@ def generate_test_description():
                 min_error, value_type=float),
             "max_translation_error": ParameterValue(
                 max_error, value_type=float),
+            "meaningful_yaw": ParameterValue(
+                meaningful_yaw, value_type=float),
+            "max_yaw_error": ParameterValue(
+                max_yaw_error, value_type=float),
         }],
         output="screen",
     )
 
     return LaunchDescription([
         DeclareLaunchArgument("motion_profile", default_value="stress"),
+        DeclareLaunchArgument("motion", default_value="strafe"),
+        DeclareLaunchArgument("command_speed", default_value="0.2"),
         DeclareLaunchArgument("min_error", default_value="0.003"),
         DeclareLaunchArgument("max_error", default_value="0.030"),
+        DeclareLaunchArgument("meaningful_yaw", default_value="0.8"),
+        DeclareLaunchArgument("max_yaw_error", default_value="0.005"),
         SetEnvironmentVariable(
             "IGN_PARTITION", f"yahboom_profile_divergence_{os.getpid()}"),
         SetEnvironmentVariable("ROS_DOMAIN_ID", str(10 + os.getpid() % 211)),


### PR DESCRIPTION
## Summary

- correct the physical wheel joint and collision centres to the real 0.169 m separation
- add an ideal yaw regression protecting the corrected rotational kinematics
- preserve raw Gazebo ground truth as a measurement-only world-frame topic
- align the separate ground-truth display frame for nonzero spawns and SLAM maps
- freeze the map/world alignment so later map-to-odom corrections do not move truth
- document the transform contract, launch option, rationale, and deferred work

## Compatibility

- no robot topic, joint, model, sensor, or robot-frame names change
- wheel-state odometry remains the sole odom-to-base transform authority
- raw ground truth remains world to base_footprint and is not used by navigation
- the new behavior affects only wheel physical centres and the separate ground_truth_base diagnostic frame

## Validation

- [x] three-package isolated build
- [x] robot description contract
- [x] ideal yaw odometry-versus-ground-truth regression
- [x] live Gazebo ground-truth topic contract
- [x] synthetic nonzero-spawn and changing-map display regression
- [x] base-feedback and wheel-odometry authority regressions
- [x] Python and CMake style checks

## Acceptance gate

- [ ] Validate ground_truth_base end to end with AIRclub-UdeSA/yahboom_rosmaster_slam, including map startup and an intentionally visible wheel-odometry error.

Keep this PR in draft until the acceptance gate passes. The root TODO also records this requirement and the separate SLAM-restart behavior decision.
