### PR TITLE
Superseded by #27: stabilize smoke contracts and simulator teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,13 +314,14 @@ Gazebo GUI.
 
 Every maze world above has a `world_smoke_*` launch test (see
 `test/world_smoke.launch.py`): headless spawn, no initial collision (the
-robot stays level, drifts less than 5 cm during a 3s no-command window, and
-stays within 10 cm of its expected (0, 0) spawn point), a short forward
-`/cmd_vel` command that must produce real ground-truth displacement (catching
-a robot whose wheels spin without translating), and the core topics (`/odom`,
-`/tf`, `/joint_states`, `/scan`, `/imu/data`) coming up. This is intentionally
-lighter than the `sensor_contract_*` tests on the empty and cafe worlds,
-which additionally assert message rates, latency, and payload shape -- maze
+robot stays level, never strays more than 5 cm from its first pose during a
+3s no-command window, and stays within 10 cm of its expected (0, 0) spawn
+point), a short forward `/cmd_vel` command that must produce predominantly
+forward ground-truth displacement rather than backward or sideways motion
+(also catching a robot whose wheels spin without translating), and the core
+topics (`/odom`, `/tf`, `/joint_states`, `/scan`, `/imu/data`) coming up. This
+is intentionally lighter than the `sensor_contract_*` tests on the empty and
+cafe worlds, which additionally assert message rates, latency, and payload shape -- maze
 layouts share the same robot and sensor stack, so only spawn validity and
 basic movement actually vary world to world. `_victimas` worlds get the
 same smoke test as their base layout, since the color-marker cubes are the

--- a/yahboom_rosmaster_gazebo/CMakeLists.txt
+++ b/yahboom_rosmaster_gazebo/CMakeLists.txt
@@ -54,6 +54,10 @@ if(BUILD_TESTING)
     NAME practice_world_probe_contract
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/world_smoke_probe_test.py
   )
+  add_test(
+    NAME launch_shutdown_contract
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/launch_shutdown_test.py
+  )
   add_launch_test(
     test/sensor_contract.launch.py
     TARGET sensor_contract_empty

--- a/yahboom_rosmaster_gazebo/launch/rosmaster_gazebo_fortress.launch.py
+++ b/yahboom_rosmaster_gazebo/launch/rosmaster_gazebo_fortress.launch.py
@@ -8,6 +8,7 @@ gz_ros2_control kept read-only for joint states and wheel-link TF.
 import os
 import platform
 import shutil
+import signal
 import subprocess
 import tempfile
 import time
@@ -173,27 +174,71 @@ def _launch_rviz(context):
     return []
 
 
-def _gazebo_process_stopped(gazebo_server):
-    """Return whether the owned Gazebo process has exited or become a zombie."""
-    if gazebo_server.return_code is not None:
+def _process_stopped(process):
+    """Return whether an owned launch process has exited or become a zombie."""
+    if process.return_code is not None:
         return True
-    details = gazebo_server.process_details
+    details = process.process_details
     if details is None or "pid" not in details:
         return False
     try:
         with open(f"/proc/{details['pid']}/stat", encoding="utf-8") as stat_file:
             state = stat_file.read().rsplit(")", 1)[1].strip().split()[0]
     except FileNotFoundError:
-        return True
+        # Linux exposes live and zombie state in /proc. Platforms such as
+        # macOS do not mount /proc at all, so probe the PID there rather than
+        # mistaking every running process for one that has already exited.
+        if os.path.isdir("/proc"):
+            return True
+        try:
+            os.kill(details["pid"], 0)
+        except ProcessLookupError:
+            return True
+        except OSError:
+            return False
+        return False
     except (IndexError, OSError):
         return False
     return state == "Z"
 
 
-def _request_gazebo_stop(event, context, gazebo_server):
-    """Ask Gazebo to stop cleanly before launch falls back to process signals."""
+def _stop_image_bridge(image_bridge, logger, timeout=2.0):
+    """Stop the image consumer before its Gazebo publishers disappear."""
+    if _process_stopped(image_bridge):
+        return
+
+    details = image_bridge.process_details
+    if details is None or "pid" not in details:
+        logger.debug("Image bridge was not started before shutdown")
+        return
+
+    try:
+        logger.info("Stopping the image bridge before Gazebo sensor shutdown")
+        os.kill(details["pid"], signal.SIGINT)
+    except ProcessLookupError:
+        return
+    except OSError as exception:
+        logger.warning(
+            f"Could not stop the image bridge before Gazebo: {exception}")
+        return
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if _process_stopped(image_bridge):
+            logger.info("Image bridge stopped before Gazebo sensor shutdown")
+            return
+        time.sleep(0.05)
+    logger.warning(
+        f"Image bridge did not stop within {timeout:.1f} seconds; continuing "
+        "with Gazebo shutdown and launch signal fallback")
+
+
+def _request_gazebo_stop(event, context, gazebo_server, image_bridge):
+    """Stop transport consumers, then Gazebo, before launch signal fallback."""
     del event
     logger = get_logger("rosmaster_gazebo_shutdown")
+    _stop_image_bridge(image_bridge, logger)
+
     ign_executable = shutil.which("ign")
     if ign_executable is None:
         logger.warning("Cannot request Gazebo stop: 'ign' is not available")
@@ -230,7 +275,7 @@ def _request_gazebo_stop(event, context, gazebo_server):
         logger.info("Gazebo acknowledged the clean stop request")
         deadline = time.monotonic() + 4.0
         while time.monotonic() < deadline:
-            if _gazebo_process_stopped(gazebo_server):
+            if _process_stopped(gazebo_server):
                 logger.info("Gazebo completed its clean stop before signal fallback")
                 break
             time.sleep(0.05)
@@ -241,7 +286,7 @@ def _request_gazebo_stop(event, context, gazebo_server):
     return None
 
 
-def _launch_gazebo_server(context, ign_executable, pkg_gz):
+def _launch_gazebo_server(context, ign_executable, pkg_gz, image_bridge):
     raw_world = LaunchConfiguration("world").perform(context)
     if os.path.isabs(raw_world) and os.path.exists(raw_world):
         world_path = raw_world
@@ -269,7 +314,7 @@ def _launch_gazebo_server(context, ign_executable, pkg_gz):
     return [
         RegisterEventHandler(OnShutdown(
             on_shutdown=lambda event, ctx: _request_gazebo_stop(
-                event, ctx, gazebo_server))),
+                event, ctx, gazebo_server, image_bridge))),
         gazebo_server,
     ]
 
@@ -512,7 +557,7 @@ def generate_launch_description():
         AppendEnvironmentVariable("GZ_SIM_RESOURCE_PATH", os.path.join(pkg_gz, "worlds")),
         OpaqueFunction(
             function=_launch_gazebo_server,
-            args=[ign_executable, pkg_gz],
+            args=[ign_executable, pkg_gz, ros_gz_image_bridge],
         ),
         gazebo_client,
         OpaqueFunction(

--- a/yahboom_rosmaster_gazebo/scripts/world_smoke_probe.py
+++ b/yahboom_rosmaster_gazebo/scripts/world_smoke_probe.py
@@ -24,8 +24,9 @@ from tf2_msgs.msg import TFMessage
 
 GROUND_TRUTH_TOPIC = "/ground_truth/odom"
 REQUIRED_DYNAMIC_TF_EDGE = ("odom", "base_footprint")
-MAX_SETTLED_DRIFT_M = 0.05
+MAX_SETTLED_EXCURSION_M = 0.05
 MAX_LEVEL_ANGLE_RAD = 0.15
+MAX_LATERAL_DISPLACEMENT_M = 0.05
 # The spawn action never sets -x/-y, so every world spawns the robot at the
 # origin. A settled offset past this means the robot was pushed off spawn
 # (e.g. wedged against a wall) before the probe started observing.
@@ -46,6 +47,14 @@ def quaternion_to_roll_pitch(orientation):
     sinp = max(-1.0, min(1.0, 2.0 * (w * y - z * x)))
     pitch = math.asin(sinp)
     return roll, pitch
+
+
+def quaternion_to_yaw(orientation):
+    """Convert a quaternion to yaw in radians."""
+    x, y, z, w = orientation.x, orientation.y, orientation.z, orientation.w
+    siny_cosp = 2.0 * (w * z + x * y)
+    cosy_cosp = 1.0 - 2.0 * (y * y + z * z)
+    return math.atan2(siny_cosp, cosy_cosp)
 
 
 class WorldSmokeProbe(Node):
@@ -150,7 +159,7 @@ class WorldSmokeProbe(Node):
         return elapsed
 
     def validate_motion(self, start, end, command_elapsed):
-        """Return errors if a short forward command produced no real displacement."""
+        """Return errors if a short forward command did not move mostly forward."""
         if start is None or end is None:
             return ["no ground-truth sample available to validate movement"]
         if not math.isfinite(command_elapsed):
@@ -162,19 +171,52 @@ class WorldSmokeProbe(Node):
                 "forward /cmd_vel command before the wall timeout -- cannot "
                 "validate movement"
             ]
-        displacement = math.dist(
-            (start.pose.pose.position.x, start.pose.pose.position.y),
-            (end.pose.pose.position.x, end.pose.pose.position.y),
+        start_position = start.pose.pose.position
+        end_position = end.pose.pose.position
+        start_orientation = start.pose.pose.orientation
+        pose_values = (
+            start_position.x, start_position.y,
+            end_position.x, end_position.y,
+            start_orientation.x, start_orientation.y,
+            start_orientation.z, start_orientation.w,
         )
-        if not math.isfinite(displacement):
-            return [f"{GROUND_TRUTH_TOPIC}: movement displacement is non-finite"]
-        if displacement < self.meaningful_motion:
-            return [
-                f"{GROUND_TRUTH_TOPIC}: moved only {displacement:.3f}m over a "
+        if not all(math.isfinite(value) for value in pose_values):
+            return [f"{GROUND_TRUTH_TOPIC}: movement pose has non-finite values"]
+
+        delta_x = end_position.x - start_position.x
+        delta_y = end_position.y - start_position.y
+        initial_yaw = quaternion_to_yaw(start_orientation)
+        forward_displacement = (
+            math.cos(initial_yaw) * delta_x + math.sin(initial_yaw) * delta_y
+        )
+        lateral_displacement = (
+            -math.sin(initial_yaw) * delta_x + math.cos(initial_yaw) * delta_y
+        )
+
+        errors = []
+        if forward_displacement < 0.0:
+            errors.append(
+                f"{GROUND_TRUTH_TOPIC}: moved {abs(forward_displacement):.3f}m "
+                f"backward over a {self.command_duration:.1f}s forward /cmd_vel "
+                f"command (expected at least {self.meaningful_motion:.3f}m "
+                "forward)"
+            )
+        elif forward_displacement < self.meaningful_motion:
+            errors.append(
+                f"{GROUND_TRUTH_TOPIC}: moved only "
+                f"{forward_displacement:.3f}m forward over a "
                 f"{self.command_duration:.1f}s forward /cmd_vel command "
                 f"(expected at least {self.meaningful_motion:.3f}m) -- wheels "
-                "may be spinning without translating"]
-        return []
+                "may be spinning without translating"
+            )
+        if abs(lateral_displacement) > MAX_LATERAL_DISPLACEMENT_M:
+            errors.append(
+                f"{GROUND_TRUTH_TOPIC}: moved {abs(lateral_displacement):.3f}m "
+                f"laterally over a forward /cmd_vel command (maximum allowed "
+                f"{MAX_LATERAL_DISPLACEMENT_M:.3f}m) -- motion was not "
+                "predominantly forward"
+            )
+        return errors
 
     def complete(self):
         """Return whether the settle window has elapsed and every topic was seen."""
@@ -228,23 +270,34 @@ class WorldSmokeProbe(Node):
                 f"expected (0, 0) spawn point -- the robot was likely pushed "
                 "off spawn before the probe started observing")
 
-        drift = math.dist(
-            (
-                first.pose.pose.position.x,
-                first.pose.pose.position.y,
-                first.pose.pose.position.z,
-            ),
-            (
-                last.pose.pose.position.x,
-                last.pose.pose.position.y,
-                last.pose.pose.position.z,
-            ),
+        first_position = first.pose.pose.position
+        observed_positions = []
+        for index, message in enumerate(self.ground_truth):
+            position = message.pose.pose.position
+            values = (position.x, position.y, position.z)
+            if not all(math.isfinite(value) for value in values):
+                errors.append(
+                    f"{GROUND_TRUTH_TOPIC}: sample {index} position has "
+                    "non-finite values"
+                )
+                continue
+            observed_positions.append(values)
+        if errors:
+            return errors
+
+        max_excursion = max(
+            math.dist(
+                (first_position.x, first_position.y, first_position.z),
+                position,
+            )
+            for position in observed_positions
         )
-        if drift > MAX_SETTLED_DRIFT_M:
+        if max_excursion > MAX_SETTLED_EXCURSION_M:
             errors.append(
-                f"{GROUND_TRUTH_TOPIC}: drifted {drift:.3f}m with no command over "
-                f"{self.settle_window:.1f}s -- likely an initial collision or "
-                "spawn on unstable geometry")
+                f"{GROUND_TRUTH_TOPIC}: reached a maximum excursion of "
+                f"{max_excursion:.3f}m from its first observed pose with no "
+                f"command over {self.settle_window:.1f}s -- likely an initial "
+                "collision or spawn on unstable geometry")
 
         return errors
 

--- a/yahboom_rosmaster_gazebo/test/launch_shutdown_test.py
+++ b/yahboom_rosmaster_gazebo/test/launch_shutdown_test.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Focused unit tests for dependency-aware simulator shutdown helpers."""
+
+import importlib.util
+from pathlib import Path
+import signal
+from types import SimpleNamespace
+import unittest
+from unittest.mock import patch
+
+
+LAUNCH_FILE = (
+    Path(__file__).resolve().parents[1]
+    / "launch"
+    / "rosmaster_gazebo_fortress.launch.py"
+)
+SPEC = importlib.util.spec_from_file_location("rosmaster_gazebo_fortress", LAUNCH_FILE)
+LAUNCH_MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(LAUNCH_MODULE)
+
+
+class RecordingLogger:
+    """Collect helper logs without depending on launch's logging backend."""
+
+    def __init__(self):
+        self.debug_messages = []
+        self.info_messages = []
+        self.warning_messages = []
+
+    def debug(self, message):
+        self.debug_messages.append(message)
+
+    def info(self, message):
+        self.info_messages.append(message)
+
+    def warning(self, message):
+        self.warning_messages.append(message)
+
+
+class FakeProcess:
+    """Expose the two launch-process properties used by the helpers."""
+
+    def __init__(self, return_code=None, process_details=None):
+        self.return_code = return_code
+        self.process_details = process_details
+
+
+class TestLaunchShutdown(unittest.TestCase):
+    """Require the image consumer to stop before Gazebo is torn down."""
+
+    def test_proc_unavailable_probes_live_pid(self):
+        process = FakeProcess(process_details={"pid": 123})
+
+        with (
+            patch("builtins.open", side_effect=FileNotFoundError),
+            patch.object(LAUNCH_MODULE.os.path, "isdir", return_value=False),
+            patch.object(LAUNCH_MODULE.os, "kill") as kill,
+        ):
+            stopped = LAUNCH_MODULE._process_stopped(process)
+
+        self.assertFalse(stopped)
+        kill.assert_called_once_with(123, 0)
+
+    def test_proc_unavailable_detects_missing_pid(self):
+        process = FakeProcess(process_details={"pid": 123})
+
+        with (
+            patch("builtins.open", side_effect=FileNotFoundError),
+            patch.object(LAUNCH_MODULE.os.path, "isdir", return_value=False),
+            patch.object(
+                LAUNCH_MODULE.os, "kill", side_effect=ProcessLookupError),
+        ):
+            stopped = LAUNCH_MODULE._process_stopped(process)
+
+        self.assertTrue(stopped)
+
+    def test_unstarted_bridge_is_safe(self):
+        logger = RecordingLogger()
+        bridge = FakeProcess()
+
+        with patch.object(LAUNCH_MODULE.os, "kill") as kill:
+            LAUNCH_MODULE._stop_image_bridge(bridge, logger)
+
+        kill.assert_not_called()
+        self.assertTrue(any("not started" in message for message in logger.debug_messages))
+
+    def test_stopped_bridge_is_ignored(self):
+        logger = RecordingLogger()
+        bridge = FakeProcess(return_code=0, process_details={"pid": 123})
+
+        with patch.object(LAUNCH_MODULE.os, "kill") as kill:
+            LAUNCH_MODULE._stop_image_bridge(bridge, logger)
+
+        kill.assert_not_called()
+
+    def test_bridge_receives_sigint_and_is_awaited(self):
+        logger = RecordingLogger()
+        bridge = FakeProcess(process_details={"pid": 123})
+
+        with (
+            patch.object(
+                LAUNCH_MODULE,
+                "_process_stopped",
+                side_effect=(False, False, True),
+            ),
+            patch.object(LAUNCH_MODULE.os, "kill") as kill,
+            patch.object(
+                LAUNCH_MODULE.time,
+                "monotonic",
+                side_effect=(0.0, 0.0, 0.1),
+            ),
+            patch.object(LAUNCH_MODULE.time, "sleep"),
+        ):
+            LAUNCH_MODULE._stop_image_bridge(bridge, logger)
+
+        kill.assert_called_once_with(123, signal.SIGINT)
+        self.assertTrue(any("stopped before" in message for message in logger.info_messages))
+        self.assertEqual(logger.warning_messages, [])
+
+    def test_bridge_wait_is_bounded(self):
+        logger = RecordingLogger()
+        bridge = FakeProcess(process_details={"pid": 123})
+
+        with (
+            patch.object(LAUNCH_MODULE, "_process_stopped", return_value=False),
+            patch.object(LAUNCH_MODULE.os, "kill") as kill,
+            patch.object(LAUNCH_MODULE.time, "monotonic", return_value=1.0),
+        ):
+            LAUNCH_MODULE._stop_image_bridge(bridge, logger, timeout=0.0)
+
+        kill.assert_called_once_with(123, signal.SIGINT)
+        self.assertTrue(any("did not stop" in message for message in logger.warning_messages))
+
+    def test_bridge_is_stopped_before_gazebo_service_request(self):
+        calls = []
+        context = SimpleNamespace(environment={})
+        gazebo = FakeProcess(process_details={"pid": 456})
+        bridge = FakeProcess(process_details={"pid": 123})
+
+        def record_bridge_stop(*args):
+            del args
+            calls.append("image_bridge")
+
+        def record_gazebo_stop(*args, **kwargs):
+            del args, kwargs
+            calls.append("gazebo")
+            return SimpleNamespace(
+                returncode=0, stdout="data: true", stderr="")
+
+        with (
+            patch.object(
+                LAUNCH_MODULE, "_stop_image_bridge",
+                side_effect=record_bridge_stop,
+            ),
+            patch.object(LAUNCH_MODULE.shutil, "which", return_value="/usr/bin/ign"),
+            patch.object(
+                LAUNCH_MODULE.subprocess, "run",
+                side_effect=record_gazebo_stop,
+            ),
+            patch.object(LAUNCH_MODULE, "_process_stopped", return_value=True),
+        ):
+            LAUNCH_MODULE._request_gazebo_stop(None, context, gazebo, bridge)
+
+        self.assertEqual(calls, ["image_bridge", "gazebo"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/yahboom_rosmaster_gazebo/test/world_smoke.launch.py
+++ b/yahboom_rosmaster_gazebo/test/world_smoke.launch.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Launch a practice world headless and require the spawn smoke contract to pass."""
+"""Launch a practice world headless and require its smoke contract to pass."""
 
 import os
 
@@ -7,10 +7,16 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import (
     DeclareLaunchArgument,
+    EmitEvent,
+    ExecuteProcess,
     IncludeLaunchDescription,
+    LogInfo,
+    RegisterEventHandler,
     SetEnvironmentVariable,
     TimerAction,
 )
+from launch.event_handlers import OnProcessExit
+from launch.events import Shutdown
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
@@ -21,13 +27,40 @@ import pytest
 import unittest
 
 
+GROUND_TRUTH_READY_TIMEOUT = 20.0
+
+
+def _start_probe_after_ground_truth(
+        event, context, probe, readiness_timeout):
+    """Start the probe after the simulator publishes robot pose."""
+    readiness_timeout.cancel()
+    # A timeout-triggered launch shutdown can make the readiness process exit
+    # while this handler is still registered. Never start the probe during
+    # teardown or emit a redundant Shutdown event.
+    if context.is_shutdown:
+        return []
+    if event.returncode != 0:
+        return [EmitEvent(event=Shutdown(
+            reason=(
+                "ground-truth readiness process exited with code "
+                f"{event.returncode} before the smoke probe could start"
+            ),
+        ))]
+    return [
+        LogInfo(
+            msg="Ground truth is publishing; starting the world smoke probe"),
+        probe,
+    ]
+
+
 @pytest.mark.launch_test
 def generate_test_description():
     package_share = get_package_share_directory("yahboom_rosmaster_gazebo")
     world = LaunchConfiguration("world")
     simulator = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            os.path.join(package_share, "launch", "rosmaster_gazebo_fortress.launch.py")
+            os.path.join(
+                package_share, "launch", "rosmaster_gazebo_fortress.launch.py")
         ),
         launch_arguments={
             "headless": "true",
@@ -37,7 +70,7 @@ def generate_test_description():
             # The probe commands a short forward move to confirm the world
             # doesn't block translation (world_smoke_probe.py checks this
             # against a fixed meaningful_motion distance), so the /cmd_vel
-            # motion bias -- resampled at random per launch -- must be off.
+            # motion bias, resampled at random per launch, must be off.
             "motion_bias": "false",
         }.items(),
     )
@@ -53,6 +86,43 @@ def generate_test_description():
         }],
         output="screen",
     )
+    # Start listening before the simulator so the probe is launched on the
+    # first bridged robot-pose sample instead of after an assumed wall-clock
+    # startup duration. Ground truth is emitted only after Gazebo has spawned
+    # the robot and the bridge is active; the probe itself then owns the richer
+    # settle/interface checks.
+    ground_truth_ready = ExecuteProcess(
+        cmd=[
+            "ros2", "topic", "echo",
+            "--once",
+            "--no-daemon",
+            "--qos-reliability", "best_effort",
+            "--field", "header.stamp",
+            "/ground_truth/odom", "nav_msgs/msg/Odometry",
+        ],
+        name="wait_for_ground_truth",
+        output="screen",
+    )
+    # Bound the readiness gate before the active test's 30-second startup wait.
+    # Together with the probe's 32-second budget, this leaves 18 seconds inside
+    # each CTest target's 70-second limit for launch and simulator teardown.
+    readiness_timeout = TimerAction(
+        period=GROUND_TRUTH_READY_TIMEOUT,
+        actions=[
+            LogInfo(msg=(
+                "Timed out waiting for /ground_truth/odom; "
+                "shutting down the world smoke test")),
+            EmitEvent(event=Shutdown(
+                reason=(
+                    "ground truth did not become ready within "
+                    f"{GROUND_TRUTH_READY_TIMEOUT:.0f} seconds"))),
+        ],
+    )
+    start_probe_when_ready = RegisterEventHandler(OnProcessExit(
+        target_action=ground_truth_ready,
+        on_exit=lambda event, context: _start_probe_after_ground_truth(
+            event, context, probe, readiness_timeout),
+    ))
 
     return LaunchDescription([
         DeclareLaunchArgument("world", default_value="empty.world"),
@@ -61,14 +131,16 @@ def generate_test_description():
         # Keep sequential world tests isolated even when their PIDs differ by a
         # round multiple of 100 (a pattern observed under CTest).
         SetEnvironmentVariable("ROS_DOMAIN_ID", str(10 + os.getpid() % 211)),
+        start_probe_when_ready,
+        readiness_timeout,
+        ground_truth_ready,
         simulator,
-        TimerAction(period=15.0, actions=[probe]),
         launch_testing.actions.ReadyToTest(),
     ]), {"probe": probe}
 
 
 class TestWorldSmoke(unittest.TestCase):
-    """Require the spawn smoke probe to finish successfully within the launch-test budget."""
+    """Require the probe to finish within the launch-test budget."""
 
     def test_probe_passes(self, proc_info, probe):
         proc_info.assertWaitForStartup(probe, timeout=30)

--- a/yahboom_rosmaster_gazebo/test/world_smoke_probe_test.py
+++ b/yahboom_rosmaster_gazebo/test/world_smoke_probe_test.py
@@ -2,6 +2,7 @@
 """Focused unit tests for the practice-world smoke probe."""
 
 from pathlib import Path
+import math
 import sys
 import unittest
 from unittest.mock import patch
@@ -17,13 +18,16 @@ import world_smoke_probe  # noqa: E402
 from world_smoke_probe import WorldSmokeProbe, stamp_seconds  # noqa: E402
 
 
-def odometry(stamp, x=0.0):
-    """Build a level ground-truth sample at a requested time and x position."""
+def odometry(stamp, x=0.0, y=0.0, z=0.0, yaw=0.0):
+    """Build a level ground-truth sample at a requested pose and time."""
     message = Odometry()
     message.header.stamp.sec = int(stamp)
     message.header.stamp.nanosec = int((stamp - int(stamp)) * 1e9)
     message.pose.pose.position.x = x
-    message.pose.pose.orientation.w = 1.0
+    message.pose.pose.position.y = y
+    message.pose.pose.position.z = z
+    message.pose.pose.orientation.z = math.sin(yaw / 2.0)
+    message.pose.pose.orientation.w = math.cos(yaw / 2.0)
     return message
 
 
@@ -69,6 +73,17 @@ class TestWorldSmokeProbe(unittest.TestCase):
         errors = self.probe.validate()
 
         self.assertTrue(any("expected (0, 0) spawn point" in error for error in errors))
+
+    def test_validate_rejects_out_and_back_spawn_excursion(self):
+        self.probe.ground_truth = [
+            odometry(0.0),
+            odometry(1.5, x=0.08),
+            odometry(3.0),
+        ]
+
+        errors = self.probe.validate()
+
+        self.assertTrue(any("maximum excursion" in error for error in errors))
 
     def test_motion_requires_full_simulation_time_window(self):
         start = odometry(0.0)
@@ -120,6 +135,40 @@ class TestWorldSmokeProbe(unittest.TestCase):
         errors = self.probe.validate_motion(start, end, command_elapsed=2.0)
 
         self.assertTrue(any("wheels may be spinning" in error for error in errors))
+
+    def test_motion_rejects_backward_displacement(self):
+        start = odometry(0.0)
+        end = odometry(2.0, x=-0.20)
+
+        errors = self.probe.validate_motion(start, end, command_elapsed=2.0)
+
+        self.assertTrue(any("backward" in error for error in errors))
+
+    def test_motion_reports_small_negative_displacement_as_backward(self):
+        start = odometry(0.0)
+        end = odometry(2.0, x=-0.02)
+
+        errors = self.probe.validate_motion(start, end, command_elapsed=2.0)
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("moved 0.020m backward", errors[0])
+        self.assertNotIn("-0.020m forward", errors[0])
+
+    def test_motion_rejects_lateral_displacement(self):
+        start = odometry(0.0)
+        end = odometry(2.0, y=0.20)
+
+        errors = self.probe.validate_motion(start, end, command_elapsed=2.0)
+
+        self.assertTrue(any("laterally" in error for error in errors))
+
+    def test_motion_projects_displacement_onto_initial_yaw(self):
+        start = odometry(0.0, yaw=math.pi / 2.0)
+        end = odometry(2.0, y=0.20, yaw=0.0)
+
+        errors = self.probe.validate_motion(start, end, command_elapsed=2.0)
+
+        self.assertEqual(errors, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The practice-world smoke tests could produce false passes or intermittent failures:

- startup relied on a fixed 15-second delay;
- motion validation accepted backward or sideways displacement;
- settle validation compared only the first and final poses, missing out-and-back excursions;
- Gazebo could shut down before `ros_gz_image`, intermittently crashing the image bridge during teardown.

## Solution

- Start the smoke probe when `/ground_truth/odom` first publishes, with a bounded readiness timeout.
- Project commanded motion into the robot's initial heading and require predominantly forward travel.
- Measure maximum uncommanded excursion over the entire settle window.
- Stop and briefly await the image bridge before requesting Gazebo shutdown.
- Add focused regression coverage for readiness, motion direction, excursion detection, shutdown ordering, timeout fallback, and non-`/proc` platforms.
- Update the simulator testing documentation to match the strengthened contracts.

## Validation

- Maze 3 regression soak: **20/20 passed**
- All practice worlds: **8/8 passed**
- Empty and cafe sensor contracts: **2/2 passed**
- Stability result tree: **52 tests, 0 failures**
- Build, unit tests, lint, and XML checks passed
- Early-shutdown test left no orphan simulator processes
- No image-bridge crashes or teardown error signatures observed

## Risk

- The stricter smoke criteria may expose existing world or motion instability that older checks overlooked.
- Startup now fails explicitly if ground truth is unavailable after 20 seconds; very slow environments may need that budget adjusted.
- Shutdown waits at most two seconds for the image bridge, then preserves the existing launch fallback so teardown cannot block indefinitely.
