### PR TITLE
fix(simulator): align wheel centers with measured geometry

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -30,8 +30,8 @@ these items.
 
 ## Physics and runtime architecture
 
-- [ ] Evaluate correcting the physical wheel joint and collision centres to
-  match the assembled CAD and the drive plugin's 0.169 m wheel separation.
+- [x] Correct the physical wheel joint and collision centres to match the
+  measured real-robot geometry and the drive plugin's 0.169 m wheel separation.
 - [ ] Evaluate Gazebo's native joint-state publisher as a separate architectural
   change, including publication rate, headers, startup, and shutdown behavior.
 - [ ] Evaluate renderer visibility masks only if raw sensor messages show robot
@@ -41,7 +41,7 @@ these items.
 
 ## Automated contracts
 
-- [ ] Add a focused description contract test covering links, joints, sensor
+- [x] Add a focused description contract test covering links, joints, sensor
   frames, collisions, inertia, plugins, wheel origins, and installed visuals.
 - [ ] Repeat motion-profile, wheel-odometry, TF, LiDAR, RGB-D, IMU, and headless
   launch checks after each accepted physics or sensor change.

--- a/yahboom_rosmaster_description/test/robot_description_contract_test.py
+++ b/yahboom_rosmaster_description/test/robot_description_contract_test.py
@@ -12,10 +12,10 @@ ROBOT_XACRO = (
     PACKAGE_DIR / "urdf" / "robots" / "rosmaster_x3.urdf.xacro"
 )
 WHEEL_ORIGINS = {
-    "front_left": (0.08, 0.0745, -0.0325),
-    "front_right": (0.08, -0.0745, -0.0325),
-    "back_left": (-0.08, 0.0745, -0.0325),
-    "back_right": (-0.08, -0.0745, -0.0325),
+    "front_left": (0.08, 0.0845, -0.0325),
+    "front_right": (0.08, -0.0845, -0.0325),
+    "back_left": (-0.08, 0.0845, -0.0325),
+    "back_right": (-0.08, -0.0845, -0.0325),
 }
 MESHES = {
     "base_link": "rosmaster_base.obj",
@@ -28,10 +28,10 @@ MESHES = {
 }
 VISUAL_ORIGINS = {
     "base_link": (0.0, 0.0, 0.0),
-    "front_left_wheel_link": (0.0, 0.01, 0.0),
-    "front_right_wheel_link": (0.0, -0.01, 0.0),
-    "back_left_wheel_link": (0.0, 0.01, 0.0),
-    "back_right_wheel_link": (0.0, -0.01, 0.0),
+    "front_left_wheel_link": (0.0, 0.0, 0.0),
+    "front_right_wheel_link": (0.0, 0.0, 0.0),
+    "back_left_wheel_link": (0.0, 0.0, 0.0),
+    "back_right_wheel_link": (0.0, 0.0, 0.0),
     "cam_1_link": (0.0, 0.0, 0.0),
     "laser_link": (0.0, 0.0, 0.0),
 }
@@ -158,7 +158,7 @@ class TestRobotDescriptionContract(unittest.TestCase):
                     self.assertEqual(joint.get("type"), wheel_type)
                     self.assertEqual(joint.find("axis").get("xyz"), "0 1 0")
 
-    def test_wheel_joint_contract_is_unchanged(self):
+    def test_wheel_joints_match_real_robot_geometry(self):
         for backend, robot in self.robots.items():
             for side, expected in WHEEL_ORIGINS.items():
                 with self.subTest(backend=backend, wheel=side):
@@ -172,6 +172,45 @@ class TestRobotDescriptionContract(unittest.TestCase):
                         vector(joint.find("origin").get("rpy")),
                         (0.0, 0.0, 0.0),
                     )
+                    wheel_link = robot.find(
+                        f"./link[@name='{side}_wheel_link']"
+                    )
+                    for element_name in ("collision", "inertial"):
+                        origin = wheel_link.find(f"./{element_name}/origin")
+                        self.assertEqual(
+                            vector(origin.get("xyz")), (0.0, 0.0, 0.0)
+                        )
+                        self.assertEqual(
+                            vector(origin.get("rpy")), (0.0, 0.0, 0.0)
+                        )
+                    self.assertAlmostEqual(
+                        float(
+                            wheel_link.find(
+                                "./collision/geometry/sphere"
+                            ).get("radius")
+                        ),
+                        abs(expected[2]),
+                    )
+
+    def test_fortress_drive_geometry_matches_physical_wheels(self):
+        robot = self.robots["fortress"]
+        drive = robot.find(
+            ".//plugin[@name='ignition::gazebo::systems::MecanumDrive']"
+        )
+        self.assertIsNotNone(drive)
+        front_left = WHEEL_ORIGINS["front_left"]
+        front_right = WHEEL_ORIGINS["front_right"]
+        back_left = WHEEL_ORIGINS["back_left"]
+        expected = {
+            "wheelbase": abs(front_left[0] - back_left[0]),
+            "wheel_separation": abs(front_left[1] - front_right[1]),
+            "wheel_radius": abs(front_left[2]),
+        }
+        for element_name, expected_value in expected.items():
+            with self.subTest(element=element_name):
+                self.assertAlmostEqual(
+                    float(drive.findtext(element_name)), expected_value
+                )
 
     def test_sensor_frames_and_mounts_are_unchanged(self):
         for backend, robot in self.robots.items():

--- a/yahboom_rosmaster_description/urdf/mech/mecanum_wheel.urdf.xacro
+++ b/yahboom_rosmaster_description/urdf/mech/mecanum_wheel.urdf.xacro
@@ -24,7 +24,6 @@
   <xacro:property name="wheel_width"     value="0.03040" />
   <xacro:property name="wheel_mass"      value="0.05"    />
   <xacro:property name="wheel_xoff"      value="0.08"    />
-  <xacro:property name="wheel_yoff"      value="-0.01"   />
 
   <xacro:macro name="mecanum_wheel" params="
     prefix
@@ -40,10 +39,9 @@
     joint_type:=continuous">
     <link name="${prefix}${side}_wheel_link">
       <visual>
-        <!-- Keep the established joint and collision position. Moving the
-             visual 10 mm along its rotation axis matches the assembled CAD
-             without changing contact geometry or drivetrain behavior. -->
-        <origin xyz="0 ${-y_reflect*wheel_yoff} 0" rpy="0 0 0"/>
+        <!-- The generated mesh is link-local; no additional visual offset is
+             needed once the joint uses the measured lateral wheel centre. -->
+        <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
           <mesh filename="file://$(find yahboom_rosmaster_description)/meshes/rosmaster_x3/cad_visual/${side}_wheel.obj"/>
         </geometry>
@@ -79,7 +77,7 @@
       <axis xyz="0 1 0"/>
       <parent link="${prefix}base_link"/>
       <child  link="${prefix}${side}_wheel_link"/>
-      <origin xyz="${x_reflect*wheel_xoff} ${y_reflect*(wheel_separation/2+wheel_yoff)} ${-wheel_radius}"
+      <origin xyz="${x_reflect*wheel_xoff} ${y_reflect*wheel_separation/2} ${-wheel_radius}"
               rpy="0 0 0"/>
       <dynamics damping="0.1" friction="0.0"/>
     </joint>

--- a/yahboom_rosmaster_gazebo/CMakeLists.txt
+++ b/yahboom_rosmaster_gazebo/CMakeLists.txt
@@ -98,6 +98,17 @@ if(BUILD_TESTING)
     ARGS "motion_profile:=stress" "min_error:=0.003" "max_error:=0.030"
   )
   add_launch_test(
+    test/motion_profile_divergence.launch.py
+    TARGET motion_profile_yaw_ideal
+    TIMEOUT 100
+    ARGS
+      "motion_profile:=ideal"
+      "motion:=yaw"
+      "command_speed:=0.4"
+      "meaningful_yaw:=0.8"
+      "max_yaw_error:=0.005"
+  )
+  add_launch_test(
     test/lidar_geometry.launch.py
     TARGET lidar_geometry
     TIMEOUT 90

--- a/yahboom_rosmaster_gazebo/doc/deferred_simulator_changes.md
+++ b/yahboom_rosmaster_gazebo/doc/deferred_simulator_changes.md
@@ -1,23 +1,26 @@
 # Deferred simulator changes
 
-The Donatello CAD migration is intentionally visual-only. The ideas below were
-encountered while integrating and diagnosing the model, but each changes
-simulator behavior or architecture and should be evaluated independently.
+The original Donatello CAD migration was intentionally visual-only. The ideas
+below were encountered while integrating and diagnosing the model; each is
+evaluated independently, and accepted follow-ups are marked as implemented.
 
-## Correct physical wheel centres
+## Correct physical wheel centres (implemented)
 
-The drive plugin uses a `0.169 m` wheel separation, while the existing wheel
-joints and collision spheres are separated by `0.149 m`. Moving the joints from
-`y = +/-0.0745 m` to `y = +/-0.0845 m` would make the physical model agree with
-the plugin and assembled CAD.
+The physical robot description places its wheel axes at `x = +/-0.08 m` and
+approximately `y = +/-0.0845 m`: a `0.160 m` wheelbase and `0.169 m` wheel
+separation. The simulator previously subtracted a `0.01 m` lateral offset,
+leaving its joints and collision spheres only `0.149 m` apart even though the
+drive plugin and wheel-state odometry both used `0.169 m`.
 
-- Potential benefit: consistent wheel geometry, contact points, and kinematics.
-- Risk: changes existing physics, odometry behavior, and tuned motion tests.
-- Evaluate with: forward/reverse/strafe/rotation motion profiles, wheel odometry
-  divergence, and collision/contact inspection.
+The obsolete offset has been removed. Joints, collision spheres, and wheel
+inertias now use `y = +/-0.0845 m`, making contact geometry and rotational
+kinematics consistent with the real robot, drive plugin, and odometry model.
 
-For the visual migration, only the wheel meshes are shifted outward along their
-rotation axes. Joint and collision positions remain unchanged.
+The equal-and-opposite visual offsets were removed at the same time, so the CAD
+wheel meshes remain in their established rendered positions. The description
+contract protects the corrected joint origins and link-local visual origins. A
+headless ideal-profile yaw regression compares wheel odometry with raw ground
+truth after a meaningful turn.
 
 ## Controller-free joint-state path
 
@@ -114,7 +117,7 @@ remain in the package while the new model is being validated.
 
 ## Broader description contracts
 
-A focused test should protect unchanged links, joints, sensor frames,
-collisions, inertia, plugins, and installed visual assets. Renderer masks,
-alternative state sources, and corrected physics should be added to the
-contract only when those changes are separately accepted.
+A focused test protects unchanged links, joints, sensor frames, collisions,
+inertia, plugins, and installed visual assets. It also protects the accepted
+wheel-centre correction. Renderer masks and alternative state sources should
+be added to the contract only when those changes are separately accepted.

--- a/yahboom_rosmaster_gazebo/scripts/motion_profile_divergence_probe.py
+++ b/yahboom_rosmaster_gazebo/scripts/motion_profile_divergence_probe.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Measure strafe divergence between wheel odometry and ground truth."""
+"""Measure planar divergence between wheel odometry and ground truth."""
 
 import math
 import sys
@@ -31,6 +31,19 @@ def quaternion_yaw(orientation):
     return math.atan2(sin_yaw, cos_yaw)
 
 
+def normalized_angle(angle):
+    """Wrap an angle to [-pi, pi]."""
+    return math.atan2(math.sin(angle), math.cos(angle))
+
+
+def relative_yaw(start, end):
+    """Return the wrapped planar rotation between two odometry poses."""
+    return normalized_angle(
+        quaternion_yaw(end.pose.pose.orientation)
+        - quaternion_yaw(start.pose.pose.orientation)
+    )
+
+
 def relative_translation(start, end):
     """Express an odometry position delta in its initial body coordinates."""
     dx = end.pose.pose.position.x - start.pose.pose.position.x
@@ -43,11 +56,12 @@ def relative_translation(start, end):
 
 
 class MotionProfileDivergenceProbe(Node):
-    """Command one repeatable strafe and evaluate its settled endpoint error."""
+    """Command one repeatable motion and evaluate its settled endpoint error."""
 
     def __init__(self):
         super().__init__("motion_profile_divergence_probe")
         self.declare_parameter("profile", "stress")
+        self.declare_parameter("motion", "strafe")
         self.declare_parameter("timeout", 40.0)
         self.declare_parameter("command_speed", 0.2)
         self.declare_parameter("command_duration", 3.0)
@@ -56,8 +70,11 @@ class MotionProfileDivergenceProbe(Node):
         self.declare_parameter("meaningful_motion", 0.3)
         self.declare_parameter("min_translation_error", 0.003)
         self.declare_parameter("max_translation_error", 0.030)
+        self.declare_parameter("meaningful_yaw", 0.8)
+        self.declare_parameter("max_yaw_error", 0.005)
 
         self.profile = str(self.get_parameter("profile").value)
+        self.motion = str(self.get_parameter("motion").value)
         self.timeout = float(self.get_parameter("timeout").value)
         self.command_speed = float(self.get_parameter("command_speed").value)
         self.command_duration = float(
@@ -72,6 +89,10 @@ class MotionProfileDivergenceProbe(Node):
             self.get_parameter("min_translation_error").value)
         self.max_translation_error = float(
             self.get_parameter("max_translation_error").value)
+        self.meaningful_yaw = float(
+            self.get_parameter("meaningful_yaw").value)
+        self.max_yaw_error = float(
+            self.get_parameter("max_yaw_error").value)
 
         self.clock_time = None
         self.odometry = None
@@ -155,6 +176,33 @@ class MotionProfileDivergenceProbe(Node):
     def evaluate(self, start_odom, start_truth, end_odom, end_truth):
         """Return errors and a compact result string for the completed motion."""
         errors = []
+        if self.motion == "yaw":
+            odom_yaw = relative_yaw(start_odom, end_odom)
+            truth_yaw = relative_yaw(start_truth, end_truth)
+            yaw_error = abs(normalized_angle(odom_yaw - truth_yaw))
+            if not all(math.isfinite(value) for value in (
+                    odom_yaw, truth_yaw, yaw_error)):
+                errors.append("motion result contains non-finite values")
+            if abs(odom_yaw) < self.meaningful_yaw:
+                errors.append(
+                    f"wheel odometry rotated only {odom_yaw:.6f}rad; expected "
+                    f"at least {self.meaningful_yaw:.3f}rad")
+            if abs(truth_yaw) < self.meaningful_yaw:
+                errors.append(
+                    f"ground truth rotated only {truth_yaw:.6f}rad; expected "
+                    f"at least {self.meaningful_yaw:.3f}rad")
+            if yaw_error > self.max_yaw_error:
+                errors.append(
+                    f"yaw error {yaw_error:.6f}rad exceeds "
+                    f"{self.max_yaw_error:.6f}rad")
+            summary = (
+                f"profile={self.profile}, motion=yaw, "
+                f"odom_delta={odom_yaw:.6f}rad, "
+                f"truth_delta={truth_yaw:.6f}rad, "
+                f"yaw_error={yaw_error:.6f}rad"
+            )
+            return errors, summary
+
         odom_delta = relative_translation(start_odom, end_odom)
         truth_delta = relative_translation(start_truth, end_truth)
         odom_distance = math.hypot(*odom_delta)
@@ -185,7 +233,7 @@ class MotionProfileDivergenceProbe(Node):
                 f"{self.max_translation_error:.6f}]m")
 
         summary = (
-            f"profile={self.profile}, "
+            f"profile={self.profile}, motion=strafe, "
             f"odom_delta=({odom_delta[0]:.6f}, {odom_delta[1]:.6f})m, "
             f"truth_delta=({truth_delta[0]:.6f}, {truth_delta[1]:.6f})m, "
             f"translation_error={translation_error:.6f}m"
@@ -197,8 +245,18 @@ def main():
     rclpy.init()
     node = MotionProfileDivergenceProbe()
     stop = Twist()
-    strafe = Twist()
-    strafe.linear.y = node.command_speed
+    command = Twist()
+    if node.motion == "strafe":
+        command.linear.y = node.command_speed
+    elif node.motion == "yaw":
+        command.angular.z = node.command_speed
+    else:
+        node.get_logger().error(
+            f"Motion-profile divergence FAILED: unsupported motion "
+            f"{node.motion!r}")
+        node.destroy_node()
+        rclpy.shutdown()
+        return 1
     wall_deadline = time.monotonic() + node.timeout
 
     try:
@@ -224,9 +282,10 @@ def main():
         start_truth = node.ground_truth
 
         if not node.publish_until_sim_time(
-                strafe, node.command_duration, wall_deadline):
+                command, node.command_duration, wall_deadline):
             node.get_logger().error(
-                "Motion-profile divergence FAILED: strafe command timed out")
+                f"Motion-profile divergence FAILED: {node.motion} command "
+                "timed out")
             return 1
         if not node.publish_until_sim_time(
                 stop, node.final_settle_duration, wall_deadline):

--- a/yahboom_rosmaster_gazebo/test/motion_profile_divergence.launch.py
+++ b/yahboom_rosmaster_gazebo/test/motion_profile_divergence.launch.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Launch-test profile-specific odometry divergence during a strafe."""
+"""Launch-test profile-specific odometry divergence during planar motion."""
 
 import os
 import unittest
@@ -26,8 +26,12 @@ import pytest
 def generate_test_description():
     package_share = get_package_share_directory("yahboom_rosmaster_gazebo")
     motion_profile = LaunchConfiguration("motion_profile")
+    motion = LaunchConfiguration("motion")
+    command_speed = LaunchConfiguration("command_speed")
     min_error = LaunchConfiguration("min_error")
     max_error = LaunchConfiguration("max_error")
+    meaningful_yaw = LaunchConfiguration("meaningful_yaw")
+    max_yaw_error = LaunchConfiguration("max_yaw_error")
     simulator = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(
@@ -42,6 +46,9 @@ def generate_test_description():
             "use_sim_time": "true",
             "world": os.path.join(package_share, "worlds", "empty.world"),
             "motion_profile": motion_profile,
+            # Motion/odometry tests do not consume rendering sensors. Omitting
+            # them also avoids renderer-specific shutdown behavior.
+            "render_sensors": "false",
             # This test pins the divergence between commanded and achieved
             # trajectory to a numeric window, so the only perturbation must be
             # the wheel-contact profile. The /cmd_vel motion bias is resampled
@@ -54,8 +61,10 @@ def generate_test_description():
         executable="motion_profile_divergence_probe.py",
         parameters=[{
             "profile": ParameterValue(motion_profile, value_type=str),
+            "motion": ParameterValue(motion, value_type=str),
             "timeout": 40.0,
-            "command_speed": 0.2,
+            "command_speed": ParameterValue(
+                command_speed, value_type=float),
             "command_duration": 3.0,
             "initial_settle_duration": 1.0,
             "final_settle_duration": 1.0,
@@ -64,14 +73,22 @@ def generate_test_description():
                 min_error, value_type=float),
             "max_translation_error": ParameterValue(
                 max_error, value_type=float),
+            "meaningful_yaw": ParameterValue(
+                meaningful_yaw, value_type=float),
+            "max_yaw_error": ParameterValue(
+                max_yaw_error, value_type=float),
         }],
         output="screen",
     )
 
     return LaunchDescription([
         DeclareLaunchArgument("motion_profile", default_value="stress"),
+        DeclareLaunchArgument("motion", default_value="strafe"),
+        DeclareLaunchArgument("command_speed", default_value="0.2"),
         DeclareLaunchArgument("min_error", default_value="0.003"),
         DeclareLaunchArgument("max_error", default_value="0.030"),
+        DeclareLaunchArgument("meaningful_yaw", default_value="0.8"),
+        DeclareLaunchArgument("max_yaw_error", default_value="0.005"),
         SetEnvironmentVariable(
             "IGN_PARTITION", f"yahboom_profile_divergence_{os.getpid()}"),
         SetEnvironmentVariable("ROS_DOMAIN_ID", str(10 + os.getpid() % 211)),


### PR DESCRIPTION
## Reviewer guide

**Merge 2 of 2.** Review this after #27. Its base is intentionally
`ci/headless-simulator-contracts`, so the PR diff contains only the wheel-geometry
change. After #27 merges, retarget this PR to `main` and merge it second.

Review the two implementation commits:

- `39d7131` — align the simulated wheel centers with the measured track width;
- `204dbf5` — add description and ideal-yaw regressions.

Commit `03b137c` only integrates #27 into this branch. It changes no files beyond
the already validated combined tree.

## Why

The measured real-robot wheel separation is `0.168992 m` (`0.169 m` in the
simulator). The drive plugin and wheel odometry already used `0.169 m`, while the
physical wheel joints and collision centers were at `y = +/-0.0745 m`, only
`0.149 m` apart.

## What changes

- Move the wheel centers to `y = +/-0.0845 m`.
- Remove the compensating mesh offsets, preserving rendered wheel positions.
- Add description contracts tying physical geometry to the drive plugin.
- Add an ideal-yaw regression comparing wheel odometry with raw ground truth.

## Scope boundary

This PR is strictly wheel geometry and its regression coverage. It does **not**
change SLAM, `map -> odom`, spawn alignment, or ground-truth TF behavior. That
unfinished ground-truth work is tracked separately in #19; do not use old PR #11
as a merge source.

## Validation

The exact tree now at the head of this PR was validated together with #27:

- Hosted `ROS 2 Humble / Gazebo Fortress` gate on `03b137c`: **passed in
  5m33s** ([run 33465582873](https://github.com/AIRclub-UdeSA/yahboom_rosmaster/actions/runs/33465582873)).
- Combined description contract: **1/1 passed**.
- Representative Gazebo contracts: **10/10 passed**.
- Combined representative result: **11/11 passed**.
- Six workspace packages, including the external SLAM package, built successfully.
- Ideal yaw: odometry `1.197200 rad`, ground truth `1.197200 rad`, error
  `0.000000 rad`.

Earlier focused validation also passed ideal/stress strafe profiles, all eight
practice-world smoke tests, and feedback, ground-truth, IMU, and odometry
resilience contracts (**72 tests, 0 failures**).

## Merge action

1. Merge #27.
2. Retarget this PR to `main`.
3. Confirm the diff still contains only the wheel-geometry commits above.
4. Approve and merge this PR.
