### PR TITLE
test(gazebo): stabilize contracts and add the headless CI gate

### DIFF
--- a/.github/workflows/simulator-contracts.yml
+++ b/.github/workflows/simulator-contracts.yml
@@ -1,0 +1,100 @@
+name: Simulator contracts
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: simulator-contracts-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  headless-contracts:
+    name: ROS 2 Humble / Gazebo Fortress
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    container:
+      image: ros:humble-ros-base-jammy
+      options: --shm-size=2g
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      GALLIUM_DRIVER: llvmpipe
+      LIBGL_ALWAYS_SOFTWARE: "1"
+      QT_QPA_PLATFORM: xcb
+      ROS_DISTRO: humble
+      ROS_DOMAIN_ID: "42"
+      ROS_LOG_DIR: ${{ github.workspace }}/artifacts/ros-logs
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Gazebo Fortress and workspace dependencies
+        shell: bash
+        run: |
+          source /opt/ros/humble/setup.bash
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ignition-fortress \
+            libgl1-mesa-dri \
+            mesa-utils \
+            python3-colcon-common-extensions \
+            python3-rosdep \
+            ros-humble-gz-ros2-control \
+            ros-humble-ros-gz \
+            xauth \
+            xvfb
+          if [[ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]]; then
+            rosdep init
+          fi
+          rosdep update --rosdistro humble
+          rosdep install \
+            --from-paths . \
+            --ignore-src \
+            --rosdistro humble \
+            --default-yes
+
+      - name: Verify simulator environment
+        shell: bash
+        run: |
+          source /opt/ros/humble/setup.bash
+          test "$(ign gazebo --versions | cut -d. -f1)" = "6"
+          ros2 pkg prefix ros_gz_sim
+          ros2 pkg prefix gz_ros2_control
+          mkdir -p "${ROS_LOG_DIR}"
+
+      - name: Build supported packages
+        shell: bash
+        run: |
+          source /opt/ros/humble/setup.bash
+          colcon build \
+            --symlink-install \
+            --event-handlers console_direct+ \
+            --cmake-args -DBUILD_TESTING=ON
+
+      - name: Run representative headless contracts
+        shell: bash
+        timeout-minutes: 14
+        run: |
+          xvfb-run \
+            --auto-servernum \
+            --server-args="-screen 0 1280x1024x24 -nolisten tcp" \
+            bash scripts/test_simulator_contracts.sh
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: simulator-contracts-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: warn
+          retention-days: 14
+          path: |
+            build/**/test_results/**
+            build/**/Testing/**
+            log/**
+            artifacts/ros-logs/**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,12 +130,19 @@ colcon build --symlink-install
 bash src/yahboom_rosmaster/scripts/test_simulator_contracts.sh
 ```
 
-The script runs the description contract; the motion-profile, practice-world
-probe, and launch-shutdown contracts; the empty-world sensor, base-feedback,
-ground-truth, ideal-motion, and wheel-odometry-resilience launch contracts. It
-also selects the ideal-yaw contract when that target is present. Tests run
-sequentially, return a failing status to CI, and always print the complete
+The script runs the description contract; the motion-profile, practice-world,
+launch-shutdown, and sensor-probe unit contracts; the empty-world
+sensor-correctness, base-feedback, ground-truth, ideal-motion, and
+wheel-odometry-resilience launch contracts. It also selects the ideal-yaw
+contract when that target is present. Tests run sequentially, return a failing
+status to CI, and always print the complete
 `colcon test-result --verbose --all` report.
+
+The CI sensor target checks messages, payloads, frames, increasing timestamps,
+and timestamped-TF connectivity. It intentionally leaves software-rendering
+rates and first-arrival latency to the strict local `sensor_contract_empty` and
+`sensor_contract_cafe` targets, so shared-runner load cannot masquerade as a
+sensor regression.
 
 This gate is deliberately representative so that every pull request stays
 within a reasonable runtime. It does not replace the full development checks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,34 @@ Changes to `main` must go through a pull request:
    role can bypass this ruleset, but that should stay reserved for
    emergencies, not routine merges.
 
+## Headless simulator contract gate
+
+Pull requests run a representative simulator gate on Ubuntu 22.04, ROS 2
+Humble, and Gazebo Fortress. Reproduce the identical contract selection from a
+built workspace with the repository script:
+
+```bash
+cd ~/rosmaster_ws
+source /opt/ros/humble/setup.bash
+colcon build --symlink-install
+bash src/yahboom_rosmaster/scripts/test_simulator_contracts.sh
+```
+
+The script runs the description contract; the motion-profile, practice-world
+probe, and launch-shutdown contracts; the empty-world sensor, base-feedback,
+ground-truth, ideal-motion, and wheel-odometry-resilience launch contracts. It
+also selects the ideal-yaw contract when that target is present. Tests run
+sequentially, return a failing status to CI, and always print the complete
+`colcon test-result --verbose --all` report.
+
+This gate is deliberately representative so that every pull request stays
+within a reasonable runtime. It does not replace the full development checks:
+the second sensor world, stress profile, depth/LiDAR geometry and IMU-motion
+contracts, all eight practice-world smoke tests, and the repository's complete
+lint/test suite remain local/manual checks before review. Run the full suite as
+documented in [Development Checks](README.md#development-checks) when your
+change can affect those paths.
+
 ## Ground rules
 
 - This simulator is what every JAR team calibrates their challenge behavior

--- a/README.md
+++ b/README.md
@@ -314,13 +314,14 @@ Gazebo GUI.
 
 Every maze world above has a `world_smoke_*` launch test (see
 `test/world_smoke.launch.py`): headless spawn, no initial collision (the
-robot stays level, drifts less than 5 cm during a 3s no-command window, and
-stays within 10 cm of its expected (0, 0) spawn point), a short forward
-`/cmd_vel` command that must produce real ground-truth displacement (catching
-a robot whose wheels spin without translating), and the core topics (`/odom`,
-`/tf`, `/joint_states`, `/scan`, `/imu/data`) coming up. This is intentionally
-lighter than the `sensor_contract_*` tests on the empty and cafe worlds,
-which additionally assert message rates, latency, and payload shape -- maze
+robot stays level, never strays more than 5 cm from its first pose during a
+3s no-command window, and stays within 10 cm of its expected (0, 0) spawn
+point), a short forward `/cmd_vel` command that must produce predominantly
+forward ground-truth displacement rather than backward or sideways motion
+(also catching a robot whose wheels spin without translating), and the core
+topics (`/odom`, `/tf`, `/joint_states`, `/scan`, `/imu/data`) coming up. This
+is intentionally lighter than the `sensor_contract_*` tests on the empty and
+cafe worlds, which additionally assert message rates, latency, and payload shape -- maze
 layouts share the same robot and sensor stack, so only spawn validity and
 basic movement actually vary world to world. `_victimas` worlds get the
 same smoke test as their base layout, since the color-marker cubes are the

--- a/README.md
+++ b/README.md
@@ -320,8 +320,9 @@ point), a short forward `/cmd_vel` command that must produce predominantly
 forward ground-truth displacement rather than backward or sideways motion
 (also catching a robot whose wheels spin without translating), and the core
 topics (`/odom`, `/tf`, `/joint_states`, `/scan`, `/imu/data`) coming up. This
-is intentionally lighter than the `sensor_contract_*` tests on the empty and
-cafe worlds, which additionally assert message rates, latency, and payload shape -- maze
+is intentionally lighter than the strict `sensor_contract_empty` and
+`sensor_contract_cafe` tests, which additionally assert message rates, latency,
+timestamped TF, and payload shape -- maze
 layouts share the same robot and sensor stack, so only spawn validity and
 basic movement actually vary world to world. `_victimas` worlds get the
 same smoke test as their base layout, since the color-marker cubes are the
@@ -529,10 +530,17 @@ ideal-versus-stress motion-profile contract:
 
 ```bash
 colcon test --packages-select yahboom_rosmaster_gazebo \
-  --ctest-args -R '^(sensor_contract_.*|depth_geometry|ground_truth_contract|motion_profile_.*|lidar_geometry|imu_motion|base_feedback|wheel_odometry_resilience)$' \
+  --ctest-args -R '^(sensor_contract_(probe_contract|empty|cafe)|depth_geometry|ground_truth_contract|motion_profile_.*|lidar_geometry|imu_motion|base_feedback|wheel_odometry_resilience)$' \
   --output-on-failure
 colcon test-result --verbose
 ```
+
+Hosted CI runs `sensor_contract_ci` instead of those strict sensor-performance
+targets. It checks topic delivery, payloads, frames, increasing timestamps, and
+timestamped TF connectivity with three recent samples, but deliberately does
+not grade software-rendering throughput or first-arrival latency on a shared
+runner. Run `sensor_contract_empty` and `sensor_contract_cafe` locally before
+review whenever a change can affect sensor timing.
 
 The eight maze/practice worlds are covered separately by the lighter
 `world_smoke_*` tests (spawn validity, initial collisions, a forward-motion

--- a/scripts/test_simulator_contracts.sh
+++ b/scripts/test_simulator_contracts.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Run the representative headless simulator contract gate.
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# A normal ROS checkout lives at <workspace>/src/yahboom_rosmaster.  CI checks
+# the repository out directly and uses the repository root as its workspace.
+if [[ "$(basename "$(dirname "${REPO_DIR}")")" == "src" ]]; then
+    WORKSPACE_DIR="$(cd "${REPO_DIR}/../.." && pwd)"
+else
+    WORKSPACE_DIR="${REPO_DIR}"
+fi
+
+CONTRACT_REGEX='^(robot_description_contract|motion_profile_contract|practice_world_probe_contract|launch_shutdown_contract|sensor_contract_empty|base_feedback|ground_truth_contract|motion_profile_(divergence_ideal|yaw_ideal)|wheel_odometry_resilience)$'
+
+if [[ -r /opt/ros/humble/setup.bash ]]; then
+    # Workflow steps start in a fresh shell even though ROS_DISTRO is exported.
+    # shellcheck disable=SC1091
+    source /opt/ros/humble/setup.bash
+elif [[ -z "${ROS_DISTRO:-}" ]]; then
+    echo "ROS 2 is not sourced and /opt/ros/humble/setup.bash is unavailable." >&2
+    exit 2
+fi
+
+if [[ "${ROS_DISTRO}" != "humble" ]]; then
+    echo "The simulator contract gate requires ROS 2 Humble (found '${ROS_DISTRO}')." >&2
+    exit 2
+fi
+
+if [[ ! -r "${WORKSPACE_DIR}/install/setup.bash" ]]; then
+    echo "Missing ${WORKSPACE_DIR}/install/setup.bash; build the workspace first." >&2
+    exit 2
+fi
+
+# shellcheck disable=SC1090
+source "${WORKSPACE_DIR}/install/setup.bash"
+cd "${WORKSPACE_DIR}"
+
+echo "Running representative simulator contracts from ${WORKSPACE_DIR}"
+echo "CTest selection: ${CONTRACT_REGEX}"
+
+test_status=0
+colcon test \
+    --packages-select yahboom_rosmaster_description yahboom_rosmaster_gazebo \
+    --executor sequential \
+    --return-code-on-test-failure \
+    --event-handlers console_direct+ \
+    --ctest-args -R "${CONTRACT_REGEX}" --output-on-failure \
+    || test_status=$?
+
+result_status=0
+colcon test-result --verbose --all || result_status=$?
+
+if ((test_status != 0)); then
+    exit "${test_status}"
+fi
+exit "${result_status}"

--- a/scripts/test_simulator_contracts.sh
+++ b/scripts/test_simulator_contracts.sh
@@ -14,7 +14,7 @@ else
     WORKSPACE_DIR="${REPO_DIR}"
 fi
 
-CONTRACT_REGEX='^(robot_description_contract|motion_profile_contract|practice_world_probe_contract|launch_shutdown_contract|sensor_contract_empty|base_feedback|ground_truth_contract|motion_profile_(divergence_ideal|yaw_ideal)|wheel_odometry_resilience)$'
+CONTRACT_REGEX='^(robot_description_contract|motion_profile_contract|practice_world_probe_contract|launch_shutdown_contract|sensor_contract_probe_contract|sensor_contract_ci|base_feedback|ground_truth_contract|motion_profile_(divergence_ideal|yaw_ideal)|wheel_odometry_resilience)$'
 
 if [[ -r /opt/ros/humble/setup.bash ]]; then
     # Workflow steps start in a fresh shell even though ROS_DISTRO is exported.

--- a/yahboom_rosmaster_gazebo/CMakeLists.txt
+++ b/yahboom_rosmaster_gazebo/CMakeLists.txt
@@ -54,6 +54,10 @@ if(BUILD_TESTING)
     NAME practice_world_probe_contract
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/world_smoke_probe_test.py
   )
+  add_test(
+    NAME launch_shutdown_contract
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/launch_shutdown_test.py
+  )
   add_launch_test(
     test/sensor_contract.launch.py
     TARGET sensor_contract_empty

--- a/yahboom_rosmaster_gazebo/CMakeLists.txt
+++ b/yahboom_rosmaster_gazebo/CMakeLists.txt
@@ -58,6 +58,10 @@ if(BUILD_TESTING)
     NAME launch_shutdown_contract
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/launch_shutdown_test.py
   )
+  add_test(
+    NAME sensor_contract_probe_contract
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/sensor_contract_probe_test.py
+  )
   add_launch_test(
     test/sensor_contract.launch.py
     TARGET sensor_contract_empty
@@ -69,6 +73,15 @@ if(BUILD_TESTING)
     TARGET sensor_contract_cafe
     TIMEOUT 90
     ARGS "world:=cafe.world"
+  )
+  # Hosted runners use software rendering, where message delivery rate reflects
+  # runner load rather than sensor correctness.
+  # Keep the strict empty/cafe targets above for local performance validation.
+  add_launch_test(
+    test/sensor_contract.launch.py
+    TARGET sensor_contract_ci
+    TIMEOUT 90
+    ARGS "world:=empty.world" "samples:=3" "performance_checks:=false"
   )
   add_launch_test(
     test/base_feedback.launch.py

--- a/yahboom_rosmaster_gazebo/launch/rosmaster_gazebo_fortress.launch.py
+++ b/yahboom_rosmaster_gazebo/launch/rosmaster_gazebo_fortress.launch.py
@@ -8,6 +8,7 @@ gz_ros2_control kept read-only for joint states and wheel-link TF.
 import os
 import platform
 import shutil
+import signal
 import subprocess
 import tempfile
 import time
@@ -173,27 +174,71 @@ def _launch_rviz(context):
     return []
 
 
-def _gazebo_process_stopped(gazebo_server):
-    """Return whether the owned Gazebo process has exited or become a zombie."""
-    if gazebo_server.return_code is not None:
+def _process_stopped(process):
+    """Return whether an owned launch process has exited or become a zombie."""
+    if process.return_code is not None:
         return True
-    details = gazebo_server.process_details
+    details = process.process_details
     if details is None or "pid" not in details:
         return False
     try:
         with open(f"/proc/{details['pid']}/stat", encoding="utf-8") as stat_file:
             state = stat_file.read().rsplit(")", 1)[1].strip().split()[0]
     except FileNotFoundError:
-        return True
+        # Linux exposes live and zombie state in /proc. Platforms such as
+        # macOS do not mount /proc at all, so probe the PID there rather than
+        # mistaking every running process for one that has already exited.
+        if os.path.isdir("/proc"):
+            return True
+        try:
+            os.kill(details["pid"], 0)
+        except ProcessLookupError:
+            return True
+        except OSError:
+            return False
+        return False
     except (IndexError, OSError):
         return False
     return state == "Z"
 
 
-def _request_gazebo_stop(event, context, gazebo_server):
-    """Ask Gazebo to stop cleanly before launch falls back to process signals."""
+def _stop_image_bridge(image_bridge, logger, timeout=2.0):
+    """Stop the image consumer before its Gazebo publishers disappear."""
+    if _process_stopped(image_bridge):
+        return
+
+    details = image_bridge.process_details
+    if details is None or "pid" not in details:
+        logger.debug("Image bridge was not started before shutdown")
+        return
+
+    try:
+        logger.info("Stopping the image bridge before Gazebo sensor shutdown")
+        os.kill(details["pid"], signal.SIGINT)
+    except ProcessLookupError:
+        return
+    except OSError as exception:
+        logger.warning(
+            f"Could not stop the image bridge before Gazebo: {exception}")
+        return
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if _process_stopped(image_bridge):
+            logger.info("Image bridge stopped before Gazebo sensor shutdown")
+            return
+        time.sleep(0.05)
+    logger.warning(
+        f"Image bridge did not stop within {timeout:.1f} seconds; continuing "
+        "with Gazebo shutdown and launch signal fallback")
+
+
+def _request_gazebo_stop(event, context, gazebo_server, image_bridge):
+    """Stop transport consumers, then Gazebo, before launch signal fallback."""
     del event
     logger = get_logger("rosmaster_gazebo_shutdown")
+    _stop_image_bridge(image_bridge, logger)
+
     ign_executable = shutil.which("ign")
     if ign_executable is None:
         logger.warning("Cannot request Gazebo stop: 'ign' is not available")
@@ -230,7 +275,7 @@ def _request_gazebo_stop(event, context, gazebo_server):
         logger.info("Gazebo acknowledged the clean stop request")
         deadline = time.monotonic() + 4.0
         while time.monotonic() < deadline:
-            if _gazebo_process_stopped(gazebo_server):
+            if _process_stopped(gazebo_server):
                 logger.info("Gazebo completed its clean stop before signal fallback")
                 break
             time.sleep(0.05)
@@ -241,7 +286,7 @@ def _request_gazebo_stop(event, context, gazebo_server):
     return None
 
 
-def _launch_gazebo_server(context, ign_executable, pkg_gz):
+def _launch_gazebo_server(context, ign_executable, pkg_gz, image_bridge):
     raw_world = LaunchConfiguration("world").perform(context)
     if os.path.isabs(raw_world) and os.path.exists(raw_world):
         world_path = raw_world
@@ -269,7 +314,7 @@ def _launch_gazebo_server(context, ign_executable, pkg_gz):
     return [
         RegisterEventHandler(OnShutdown(
             on_shutdown=lambda event, ctx: _request_gazebo_stop(
-                event, ctx, gazebo_server))),
+                event, ctx, gazebo_server, image_bridge))),
         gazebo_server,
     ]
 
@@ -512,7 +557,7 @@ def generate_launch_description():
         AppendEnvironmentVariable("GZ_SIM_RESOURCE_PATH", os.path.join(pkg_gz, "worlds")),
         OpaqueFunction(
             function=_launch_gazebo_server,
-            args=[ign_executable, pkg_gz],
+            args=[ign_executable, pkg_gz, ros_gz_image_bridge],
         ),
         gazebo_client,
         OpaqueFunction(

--- a/yahboom_rosmaster_gazebo/launch/rosmaster_gazebo_fortress.launch.py
+++ b/yahboom_rosmaster_gazebo/launch/rosmaster_gazebo_fortress.launch.py
@@ -44,6 +44,13 @@ MOTION_PROFILE_KEYS = (
     "back_right_slip1",
 )
 
+# Software rendering can take several seconds to join Gazebo's sensor threads
+# after /server_control acknowledges a clean stop. Keep the launch shutdown
+# callback bounded, but leave enough time for llvmpipe to finish before launch
+# escalates to SIGINT (which can race SensorsPrivate::Stop).
+GAZEBO_CLEAN_STOP_TIMEOUT = 10.0
+PROCESS_STOP_POLL_INTERVAL = 0.05
+
 
 def _load_motion_profile(config_path, profile_name):
     """Load and validate one deterministic wheel-contact profile."""
@@ -202,6 +209,19 @@ def _process_stopped(process):
     return state == "Z"
 
 
+def _wait_for_process_stop(
+        process, timeout, poll_interval=PROCESS_STOP_POLL_INTERVAL):
+    """Wait at most ``timeout`` seconds for an owned process to stop."""
+    deadline = time.monotonic() + max(0.0, timeout)
+    while True:
+        if _process_stopped(process):
+            return True
+        remaining = deadline - time.monotonic()
+        if remaining <= 0.0:
+            return False
+        time.sleep(min(poll_interval, remaining))
+
+
 def _stop_image_bridge(image_bridge, logger, timeout=2.0):
     """Stop the image consumer before its Gazebo publishers disappear."""
     if _process_stopped(image_bridge):
@@ -222,12 +242,9 @@ def _stop_image_bridge(image_bridge, logger, timeout=2.0):
             f"Could not stop the image bridge before Gazebo: {exception}")
         return
 
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if _process_stopped(image_bridge):
-            logger.info("Image bridge stopped before Gazebo sensor shutdown")
-            return
-        time.sleep(0.05)
+    if _wait_for_process_stop(image_bridge, timeout):
+        logger.info("Image bridge stopped before Gazebo sensor shutdown")
+        return
     logger.warning(
         f"Image bridge did not stop within {timeout:.1f} seconds; continuing "
         "with Gazebo shutdown and launch signal fallback")
@@ -273,16 +290,13 @@ def _request_gazebo_stop(event, context, gazebo_server, image_bridge):
             f"{detail}")
     else:
         logger.info("Gazebo acknowledged the clean stop request")
-        deadline = time.monotonic() + 4.0
-        while time.monotonic() < deadline:
-            if _process_stopped(gazebo_server):
-                logger.info("Gazebo completed its clean stop before signal fallback")
-                break
-            time.sleep(0.05)
+        if _wait_for_process_stop(
+                gazebo_server, GAZEBO_CLEAN_STOP_TIMEOUT):
+            logger.info("Gazebo completed its clean stop before signal fallback")
         else:
             logger.warning(
-                "Gazebo did not finish its service-requested stop within 4 seconds; "
-                "using signal fallback")
+                "Gazebo did not finish its service-requested stop within "
+                f"{GAZEBO_CLEAN_STOP_TIMEOUT:.0f} seconds; using signal fallback")
     return None
 
 
@@ -384,6 +398,7 @@ def generate_launch_description():
     )
     headless = LaunchConfiguration("headless")
     gui = LaunchConfiguration("gui")
+    render_sensors = LaunchConfiguration("render_sensors")
 
     # Gazebo Fortress GUI — skipped when headless:=true or gui:=false.
     # QT_QPA_PLATFORM=xcb forces X11/XWayland mode on Wayland sessions;
@@ -427,6 +442,7 @@ def generate_launch_description():
             ("/cam_1/depth_image", "/cam_1/depth/image_raw"),
         ],
         output="screen",
+        condition=IfCondition(render_sensors),
     )
 
     # Fortress 6.18 labels the RGB-D cloud with the optical frame even though
@@ -438,6 +454,7 @@ def generate_launch_description():
         executable="pointcloud_frame_relay.py",
         name="pointcloud_frame_relay",
         output="screen",
+        condition=IfCondition(render_sensors),
     )
 
     # Load and activate the read-only joint state broadcaster. The spawner waits

--- a/yahboom_rosmaster_gazebo/scripts/sensor_contract_probe.py
+++ b/yahboom_rosmaster_gazebo/scripts/sensor_contract_probe.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Validate the standalone simulator's public sensor and state contract."""
 
+from collections import deque
 import math
 import sys
 import time
@@ -25,6 +26,21 @@ EXPECTED_WHEEL_JOINTS = {
 }
 CAMERA_HORIZONTAL_FOV = 1.5184
 REQUIRED_DYNAMIC_TF_EDGE = ("odom", "base_footprint")
+TIMESTAMPED_TF_TOPICS = (
+    "/scan",
+    "/imu/data",
+    "/cam_1/color/image_raw",
+    "/cam_1/depth/image_raw",
+    "/cam_1/color/camera_info",
+    "/cam_1/depth/camera_info",
+    "/cam_1/depth/color/points",
+    "/odom",
+)
+
+
+def validated_sample_count(value):
+    """Return enough samples for the third-from-last TF validation lookup."""
+    return max(3, int(value))
 
 
 class SensorContractProbe(Node):
@@ -34,8 +50,12 @@ class SensorContractProbe(Node):
         super().__init__("sensor_contract_probe")
         self.declare_parameter("timeout", 35.0)
         self.declare_parameter("samples", 3)
+        self.declare_parameter("performance_checks", True)
         self.timeout = float(self.get_parameter("timeout").value)
-        self.samples = max(2, int(self.get_parameter("samples").value))
+        self.samples = validated_sample_count(
+            self.get_parameter("samples").value)
+        self.performance_checks = bool(
+            self.get_parameter("performance_checks").value)
 
         self.required_counts = {
             "/clock": self.samples,
@@ -52,6 +72,9 @@ class SensorContractProbe(Node):
             "/tf_static": 1,
         }
         self.messages = {topic: [] for topic in self.required_counts}
+        self.recent_tf_messages = {
+            topic: deque(maxlen=3) for topic in TIMESTAMPED_TF_TOPICS
+        }
         self.observed_dynamic_tf_edges = set()
         self.started_at = time.monotonic()
         self.first_arrivals = {}
@@ -112,8 +135,14 @@ class SensorContractProbe(Node):
         self.tf_listener = TransformListener(
             self.tf_buffer, self, spin_thread=False)
 
-        self.get_logger().info(
-            f"Waiting up to {self.timeout:.1f}s for the standalone sensor contract")
+        if self.performance_checks:
+            self.get_logger().info(
+                f"Waiting up to {self.timeout:.1f}s for the standalone "
+                "sensor contract")
+        else:
+            self.get_logger().info(
+                f"Waiting up to {self.timeout:.1f}s for the "
+                "hardware-independent correctness sensor contract")
 
     def capture(self, topic, message):
         """Keep bounded samples and continuously track dynamic TF edges."""
@@ -126,6 +155,12 @@ class SensorContractProbe(Node):
                 )
                 for transform in message.transforms
             )
+        if not self.performance_checks and topic in self.recent_tf_messages:
+            # Keep exact-time TF lookups near the current simulation time while
+            # a software-rendered point cloud may lag the faster state topics.
+            # The primary evidence below remains frozen so early malformed
+            # messages cannot be hidden by later valid ones.
+            self.recent_tf_messages[topic].append(message)
         if len(self.messages[topic]) < self.required_counts[topic]:
             self.messages[topic].append(message)
 
@@ -180,18 +215,12 @@ class SensorContractProbe(Node):
 
     def validate_timestamped_tf(self, errors):
         """Require representative sensor frames to resolve at message time."""
-        topics = (
-            "/scan",
-            "/imu/data",
-            "/cam_1/color/image_raw",
-            "/cam_1/depth/image_raw",
-            "/cam_1/color/camera_info",
-            "/cam_1/depth/camera_info",
-            "/cam_1/depth/color/points",
-            "/odom",
+        tf_messages = (
+            self.messages
+            if self.performance_checks else self.recent_tf_messages
         )
-        for topic in topics:
-            message = self.messages[topic][-3]
+        for topic in TIMESTAMPED_TF_TOPICS:
+            message = tf_messages[topic][-3]
             frame = (
                 message.child_frame_id if topic == "/odom"
                 else message.header.frame_id
@@ -247,12 +276,14 @@ class SensorContractProbe(Node):
             "/joint_states": (20.0, 40.0),
             "/odom": (20.0, 40.0),
         }
-        for topic, (minimum, maximum) in rate_contracts.items():
-            self.validate_rate(topic, minimum, maximum, errors)
-            first_latency = self.first_arrivals[topic] - self.started_at
-            if first_latency > 5.0:
-                errors.append(
-                    f"{topic}: first message latency {first_latency:.3f}s exceeds 5s")
+        if self.performance_checks:
+            for topic, (minimum, maximum) in rate_contracts.items():
+                self.validate_rate(topic, minimum, maximum, errors)
+                first_latency = self.first_arrivals[topic] - self.started_at
+                if first_latency > 5.0:
+                    errors.append(
+                        f"{topic}: first message latency {first_latency:.3f}s "
+                        "exceeds 5s")
 
         color = self.messages["/cam_1/color/image_raw"][-1]
         depth = self.messages["/cam_1/depth/image_raw"][-1]

--- a/yahboom_rosmaster_gazebo/scripts/world_smoke_probe.py
+++ b/yahboom_rosmaster_gazebo/scripts/world_smoke_probe.py
@@ -24,8 +24,9 @@ from tf2_msgs.msg import TFMessage
 
 GROUND_TRUTH_TOPIC = "/ground_truth/odom"
 REQUIRED_DYNAMIC_TF_EDGE = ("odom", "base_footprint")
-MAX_SETTLED_DRIFT_M = 0.05
+MAX_SETTLED_EXCURSION_M = 0.05
 MAX_LEVEL_ANGLE_RAD = 0.15
+MAX_LATERAL_DISPLACEMENT_M = 0.05
 # The spawn action never sets -x/-y, so every world spawns the robot at the
 # origin. A settled offset past this means the robot was pushed off spawn
 # (e.g. wedged against a wall) before the probe started observing.
@@ -46,6 +47,14 @@ def quaternion_to_roll_pitch(orientation):
     sinp = max(-1.0, min(1.0, 2.0 * (w * y - z * x)))
     pitch = math.asin(sinp)
     return roll, pitch
+
+
+def quaternion_to_yaw(orientation):
+    """Convert a quaternion to yaw in radians."""
+    x, y, z, w = orientation.x, orientation.y, orientation.z, orientation.w
+    siny_cosp = 2.0 * (w * z + x * y)
+    cosy_cosp = 1.0 - 2.0 * (y * y + z * z)
+    return math.atan2(siny_cosp, cosy_cosp)
 
 
 class WorldSmokeProbe(Node):
@@ -150,7 +159,7 @@ class WorldSmokeProbe(Node):
         return elapsed
 
     def validate_motion(self, start, end, command_elapsed):
-        """Return errors if a short forward command produced no real displacement."""
+        """Return errors if a short forward command did not move mostly forward."""
         if start is None or end is None:
             return ["no ground-truth sample available to validate movement"]
         if not math.isfinite(command_elapsed):
@@ -162,19 +171,52 @@ class WorldSmokeProbe(Node):
                 "forward /cmd_vel command before the wall timeout -- cannot "
                 "validate movement"
             ]
-        displacement = math.dist(
-            (start.pose.pose.position.x, start.pose.pose.position.y),
-            (end.pose.pose.position.x, end.pose.pose.position.y),
+        start_position = start.pose.pose.position
+        end_position = end.pose.pose.position
+        start_orientation = start.pose.pose.orientation
+        pose_values = (
+            start_position.x, start_position.y,
+            end_position.x, end_position.y,
+            start_orientation.x, start_orientation.y,
+            start_orientation.z, start_orientation.w,
         )
-        if not math.isfinite(displacement):
-            return [f"{GROUND_TRUTH_TOPIC}: movement displacement is non-finite"]
-        if displacement < self.meaningful_motion:
-            return [
-                f"{GROUND_TRUTH_TOPIC}: moved only {displacement:.3f}m over a "
+        if not all(math.isfinite(value) for value in pose_values):
+            return [f"{GROUND_TRUTH_TOPIC}: movement pose has non-finite values"]
+
+        delta_x = end_position.x - start_position.x
+        delta_y = end_position.y - start_position.y
+        initial_yaw = quaternion_to_yaw(start_orientation)
+        forward_displacement = (
+            math.cos(initial_yaw) * delta_x + math.sin(initial_yaw) * delta_y
+        )
+        lateral_displacement = (
+            -math.sin(initial_yaw) * delta_x + math.cos(initial_yaw) * delta_y
+        )
+
+        errors = []
+        if forward_displacement < 0.0:
+            errors.append(
+                f"{GROUND_TRUTH_TOPIC}: moved {abs(forward_displacement):.3f}m "
+                f"backward over a {self.command_duration:.1f}s forward /cmd_vel "
+                f"command (expected at least {self.meaningful_motion:.3f}m "
+                "forward)"
+            )
+        elif forward_displacement < self.meaningful_motion:
+            errors.append(
+                f"{GROUND_TRUTH_TOPIC}: moved only "
+                f"{forward_displacement:.3f}m forward over a "
                 f"{self.command_duration:.1f}s forward /cmd_vel command "
                 f"(expected at least {self.meaningful_motion:.3f}m) -- wheels "
-                "may be spinning without translating"]
-        return []
+                "may be spinning without translating"
+            )
+        if abs(lateral_displacement) > MAX_LATERAL_DISPLACEMENT_M:
+            errors.append(
+                f"{GROUND_TRUTH_TOPIC}: moved {abs(lateral_displacement):.3f}m "
+                f"laterally over a forward /cmd_vel command (maximum allowed "
+                f"{MAX_LATERAL_DISPLACEMENT_M:.3f}m) -- motion was not "
+                "predominantly forward"
+            )
+        return errors
 
     def complete(self):
         """Return whether the settle window has elapsed and every topic was seen."""
@@ -228,23 +270,34 @@ class WorldSmokeProbe(Node):
                 f"expected (0, 0) spawn point -- the robot was likely pushed "
                 "off spawn before the probe started observing")
 
-        drift = math.dist(
-            (
-                first.pose.pose.position.x,
-                first.pose.pose.position.y,
-                first.pose.pose.position.z,
-            ),
-            (
-                last.pose.pose.position.x,
-                last.pose.pose.position.y,
-                last.pose.pose.position.z,
-            ),
+        first_position = first.pose.pose.position
+        observed_positions = []
+        for index, message in enumerate(self.ground_truth):
+            position = message.pose.pose.position
+            values = (position.x, position.y, position.z)
+            if not all(math.isfinite(value) for value in values):
+                errors.append(
+                    f"{GROUND_TRUTH_TOPIC}: sample {index} position has "
+                    "non-finite values"
+                )
+                continue
+            observed_positions.append(values)
+        if errors:
+            return errors
+
+        max_excursion = max(
+            math.dist(
+                (first_position.x, first_position.y, first_position.z),
+                position,
+            )
+            for position in observed_positions
         )
-        if drift > MAX_SETTLED_DRIFT_M:
+        if max_excursion > MAX_SETTLED_EXCURSION_M:
             errors.append(
-                f"{GROUND_TRUTH_TOPIC}: drifted {drift:.3f}m with no command over "
-                f"{self.settle_window:.1f}s -- likely an initial collision or "
-                "spawn on unstable geometry")
+                f"{GROUND_TRUTH_TOPIC}: reached a maximum excursion of "
+                f"{max_excursion:.3f}m from its first observed pose with no "
+                f"command over {self.settle_window:.1f}s -- likely an initial "
+                "collision or spawn on unstable geometry")
 
         return errors
 

--- a/yahboom_rosmaster_gazebo/test/base_feedback.launch.py
+++ b/yahboom_rosmaster_gazebo/test/base_feedback.launch.py
@@ -25,6 +25,7 @@ def generate_test_description():
             "headless": "true",
             "rviz": "false",
             "use_sim_time": "true",
+            "render_sensors": "false",
             "world": os.path.join(package_share, "worlds", "empty.world"),
         }.items(),
     )

--- a/yahboom_rosmaster_gazebo/test/ground_truth_contract.launch.py
+++ b/yahboom_rosmaster_gazebo/test/ground_truth_contract.launch.py
@@ -30,6 +30,7 @@ def generate_test_description():
             "headless": "true",
             "rviz": "false",
             "use_sim_time": "true",
+            "render_sensors": "false",
             "world": os.path.join(package_share, "worlds", "empty.world"),
             "motion_profile": "stress",
         }.items(),

--- a/yahboom_rosmaster_gazebo/test/imu_motion.launch.py
+++ b/yahboom_rosmaster_gazebo/test/imu_motion.launch.py
@@ -26,6 +26,7 @@ def generate_test_description():
             "headless": "true",
             "rviz": "false",
             "use_sim_time": "true",
+            "render_sensors": "false",
             "world": os.path.join(package_share, "worlds", "empty.world"),
         }.items(),
     )

--- a/yahboom_rosmaster_gazebo/test/launch_shutdown_test.py
+++ b/yahboom_rosmaster_gazebo/test/launch_shutdown_test.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Focused unit tests for dependency-aware simulator shutdown helpers."""
+
+import importlib.util
+from pathlib import Path
+import signal
+from types import SimpleNamespace
+import unittest
+from unittest.mock import patch
+
+
+LAUNCH_FILE = (
+    Path(__file__).resolve().parents[1]
+    / "launch"
+    / "rosmaster_gazebo_fortress.launch.py"
+)
+SPEC = importlib.util.spec_from_file_location("rosmaster_gazebo_fortress", LAUNCH_FILE)
+LAUNCH_MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(LAUNCH_MODULE)
+
+
+class RecordingLogger:
+    """Collect helper logs without depending on launch's logging backend."""
+
+    def __init__(self):
+        self.debug_messages = []
+        self.info_messages = []
+        self.warning_messages = []
+
+    def debug(self, message):
+        self.debug_messages.append(message)
+
+    def info(self, message):
+        self.info_messages.append(message)
+
+    def warning(self, message):
+        self.warning_messages.append(message)
+
+
+class FakeProcess:
+    """Expose the two launch-process properties used by the helpers."""
+
+    def __init__(self, return_code=None, process_details=None):
+        self.return_code = return_code
+        self.process_details = process_details
+
+
+class TestLaunchShutdown(unittest.TestCase):
+    """Require the image consumer to stop before Gazebo is torn down."""
+
+    def test_proc_unavailable_probes_live_pid(self):
+        process = FakeProcess(process_details={"pid": 123})
+
+        with (
+            patch("builtins.open", side_effect=FileNotFoundError),
+            patch.object(LAUNCH_MODULE.os.path, "isdir", return_value=False),
+            patch.object(LAUNCH_MODULE.os, "kill") as kill,
+        ):
+            stopped = LAUNCH_MODULE._process_stopped(process)
+
+        self.assertFalse(stopped)
+        kill.assert_called_once_with(123, 0)
+
+    def test_proc_unavailable_detects_missing_pid(self):
+        process = FakeProcess(process_details={"pid": 123})
+
+        with (
+            patch("builtins.open", side_effect=FileNotFoundError),
+            patch.object(LAUNCH_MODULE.os.path, "isdir", return_value=False),
+            patch.object(
+                LAUNCH_MODULE.os, "kill", side_effect=ProcessLookupError),
+        ):
+            stopped = LAUNCH_MODULE._process_stopped(process)
+
+        self.assertTrue(stopped)
+
+    def test_unstarted_bridge_is_safe(self):
+        logger = RecordingLogger()
+        bridge = FakeProcess()
+
+        with patch.object(LAUNCH_MODULE.os, "kill") as kill:
+            LAUNCH_MODULE._stop_image_bridge(bridge, logger)
+
+        kill.assert_not_called()
+        self.assertTrue(any("not started" in message for message in logger.debug_messages))
+
+    def test_stopped_bridge_is_ignored(self):
+        logger = RecordingLogger()
+        bridge = FakeProcess(return_code=0, process_details={"pid": 123})
+
+        with patch.object(LAUNCH_MODULE.os, "kill") as kill:
+            LAUNCH_MODULE._stop_image_bridge(bridge, logger)
+
+        kill.assert_not_called()
+
+    def test_bridge_receives_sigint_and_is_awaited(self):
+        logger = RecordingLogger()
+        bridge = FakeProcess(process_details={"pid": 123})
+
+        with (
+            patch.object(
+                LAUNCH_MODULE,
+                "_process_stopped",
+                side_effect=(False, False, True),
+            ),
+            patch.object(LAUNCH_MODULE.os, "kill") as kill,
+            patch.object(
+                LAUNCH_MODULE.time,
+                "monotonic",
+                side_effect=(0.0, 0.0, 0.1),
+            ),
+            patch.object(LAUNCH_MODULE.time, "sleep"),
+        ):
+            LAUNCH_MODULE._stop_image_bridge(bridge, logger)
+
+        kill.assert_called_once_with(123, signal.SIGINT)
+        self.assertTrue(any("stopped before" in message for message in logger.info_messages))
+        self.assertEqual(logger.warning_messages, [])
+
+    def test_bridge_wait_is_bounded(self):
+        logger = RecordingLogger()
+        bridge = FakeProcess(process_details={"pid": 123})
+
+        with (
+            patch.object(LAUNCH_MODULE, "_process_stopped", return_value=False),
+            patch.object(LAUNCH_MODULE.os, "kill") as kill,
+            patch.object(LAUNCH_MODULE.time, "monotonic", return_value=1.0),
+        ):
+            LAUNCH_MODULE._stop_image_bridge(bridge, logger, timeout=0.0)
+
+        kill.assert_called_once_with(123, signal.SIGINT)
+        self.assertTrue(any("did not stop" in message for message in logger.warning_messages))
+
+    def test_bridge_is_stopped_before_gazebo_service_request(self):
+        calls = []
+        context = SimpleNamespace(environment={})
+        gazebo = FakeProcess(process_details={"pid": 456})
+        bridge = FakeProcess(process_details={"pid": 123})
+
+        def record_bridge_stop(*args):
+            del args
+            calls.append("image_bridge")
+
+        def record_gazebo_stop(*args, **kwargs):
+            del args, kwargs
+            calls.append("gazebo")
+            return SimpleNamespace(
+                returncode=0, stdout="data: true", stderr="")
+
+        with (
+            patch.object(
+                LAUNCH_MODULE, "_stop_image_bridge",
+                side_effect=record_bridge_stop,
+            ),
+            patch.object(LAUNCH_MODULE.shutil, "which", return_value="/usr/bin/ign"),
+            patch.object(
+                LAUNCH_MODULE.subprocess, "run",
+                side_effect=record_gazebo_stop,
+            ),
+            patch.object(LAUNCH_MODULE, "_process_stopped", return_value=True),
+        ):
+            LAUNCH_MODULE._request_gazebo_stop(None, context, gazebo, bridge)
+
+        self.assertEqual(calls, ["image_bridge", "gazebo"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/yahboom_rosmaster_gazebo/test/launch_shutdown_test.py
+++ b/yahboom_rosmaster_gazebo/test/launch_shutdown_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Focused unit tests for dependency-aware simulator shutdown helpers."""
 
+import ast
 import importlib.util
 from pathlib import Path
 import signal
@@ -17,6 +18,12 @@ LAUNCH_FILE = (
 SPEC = importlib.util.spec_from_file_location("rosmaster_gazebo_fortress", LAUNCH_FILE)
 LAUNCH_MODULE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(LAUNCH_MODULE)
+NON_RENDERING_CONTRACTS = (
+    "base_feedback.launch.py",
+    "ground_truth_contract.launch.py",
+    "imu_motion.launch.py",
+    "motion_profile_divergence.launch.py",
+)
 
 
 class RecordingLogger:
@@ -47,6 +54,52 @@ class FakeProcess:
 
 class TestLaunchShutdown(unittest.TestCase):
     """Require the image consumer to stop before Gazebo is torn down."""
+
+    def test_render_only_nodes_follow_render_sensors_flag(self):
+        tree = ast.parse(LAUNCH_FILE.read_text(encoding="utf-8"))
+        assignments = {}
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+                continue
+            target = node.targets[0]
+            if isinstance(target, ast.Name):
+                assignments[target.id] = node.value
+
+        render_sensors = assignments["render_sensors"]
+        self.assertIsInstance(render_sensors, ast.Call)
+        self.assertEqual(render_sensors.func.id, "LaunchConfiguration")
+        self.assertEqual(ast.literal_eval(render_sensors.args[0]), "render_sensors")
+
+        for action_name in ("ros_gz_image_bridge", "pointcloud_frame_relay"):
+            with self.subTest(action=action_name):
+                action = assignments[action_name]
+                conditions = [
+                    keyword.value
+                    for keyword in action.keywords
+                    if keyword.arg == "condition"
+                ]
+                self.assertEqual(len(conditions), 1)
+                condition = conditions[0]
+                self.assertIsInstance(condition, ast.Call)
+                self.assertEqual(condition.func.id, "IfCondition")
+                self.assertEqual(len(condition.args), 1)
+                self.assertEqual(condition.args[0].id, "render_sensors")
+
+    def test_non_rendering_contracts_disable_rendered_sensors(self):
+        test_directory = Path(__file__).resolve().parent
+        for filename in NON_RENDERING_CONTRACTS:
+            with self.subTest(contract=filename):
+                tree = ast.parse(
+                    (test_directory / filename).read_text(encoding="utf-8"))
+                render_values = []
+                for node in ast.walk(tree):
+                    if not isinstance(node, ast.Dict):
+                        continue
+                    for key, value in zip(node.keys, node.values):
+                        if (isinstance(key, ast.Constant)
+                                and key.value == "render_sensors"):
+                            render_values.append(ast.literal_eval(value))
+                self.assertEqual(render_values, ["false"])
 
     def test_proc_unavailable_probes_live_pid(self):
         process = FakeProcess(process_details={"pid": 123})
@@ -131,6 +184,38 @@ class TestLaunchShutdown(unittest.TestCase):
         kill.assert_called_once_with(123, signal.SIGINT)
         self.assertTrue(any("did not stop" in message for message in logger.warning_messages))
 
+    def test_process_wait_returns_after_process_stops(self):
+        process = FakeProcess(process_details={"pid": 123})
+
+        with (
+            patch.object(
+                LAUNCH_MODULE, "_process_stopped", side_effect=(False, True)),
+            patch.object(
+                LAUNCH_MODULE.time, "monotonic", side_effect=(5.0, 5.0)),
+            patch.object(LAUNCH_MODULE.time, "sleep") as sleep,
+        ):
+            stopped = LAUNCH_MODULE._wait_for_process_stop(process, timeout=1.0)
+
+        self.assertTrue(stopped)
+        sleep.assert_called_once_with(LAUNCH_MODULE.PROCESS_STOP_POLL_INTERVAL)
+
+    def test_process_wait_timeout_is_bounded(self):
+        process = FakeProcess(process_details={"pid": 123})
+
+        with (
+            patch.object(LAUNCH_MODULE, "_process_stopped", return_value=False),
+            patch.object(
+                LAUNCH_MODULE.time,
+                "monotonic",
+                side_effect=(5.0, 5.0, 5.2),
+            ),
+            patch.object(LAUNCH_MODULE.time, "sleep") as sleep,
+        ):
+            stopped = LAUNCH_MODULE._wait_for_process_stop(process, timeout=0.2)
+
+        self.assertFalse(stopped)
+        sleep.assert_called_once_with(LAUNCH_MODULE.PROCESS_STOP_POLL_INTERVAL)
+
     def test_bridge_is_stopped_before_gazebo_service_request(self):
         calls = []
         context = SimpleNamespace(environment={})
@@ -157,11 +242,45 @@ class TestLaunchShutdown(unittest.TestCase):
                 LAUNCH_MODULE.subprocess, "run",
                 side_effect=record_gazebo_stop,
             ),
-            patch.object(LAUNCH_MODULE, "_process_stopped", return_value=True),
+            patch.object(
+                LAUNCH_MODULE, "_wait_for_process_stop", return_value=True,
+            ) as wait_for_stop,
         ):
             LAUNCH_MODULE._request_gazebo_stop(None, context, gazebo, bridge)
 
         self.assertEqual(calls, ["image_bridge", "gazebo"])
+        wait_for_stop.assert_called_once_with(
+            gazebo, LAUNCH_MODULE.GAZEBO_CLEAN_STOP_TIMEOUT)
+
+    def test_gazebo_clean_stop_grace_is_bounded_and_logged(self):
+        logger = RecordingLogger()
+        context = SimpleNamespace(environment={})
+        gazebo = FakeProcess(process_details={"pid": 456})
+        bridge = FakeProcess(process_details={"pid": 123})
+
+        with (
+            patch.object(LAUNCH_MODULE, "_stop_image_bridge"),
+            patch.object(LAUNCH_MODULE.shutil, "which", return_value="/usr/bin/ign"),
+            patch.object(
+                LAUNCH_MODULE.subprocess,
+                "run",
+                return_value=SimpleNamespace(
+                    returncode=0, stdout="data: true", stderr=""),
+            ),
+            patch.object(
+                LAUNCH_MODULE, "_wait_for_process_stop", return_value=False,
+            ) as wait_for_stop,
+            patch.object(LAUNCH_MODULE, "get_logger", return_value=logger),
+        ):
+            LAUNCH_MODULE._request_gazebo_stop(None, context, gazebo, bridge)
+
+        wait_for_stop.assert_called_once_with(
+            gazebo, LAUNCH_MODULE.GAZEBO_CLEAN_STOP_TIMEOUT)
+        self.assertTrue(any(
+            f"within {LAUNCH_MODULE.GAZEBO_CLEAN_STOP_TIMEOUT:.0f} seconds"
+            in message
+            for message in logger.warning_messages
+        ))
 
 
 if __name__ == "__main__":

--- a/yahboom_rosmaster_gazebo/test/motion_profile_divergence.launch.py
+++ b/yahboom_rosmaster_gazebo/test/motion_profile_divergence.launch.py
@@ -40,6 +40,7 @@ def generate_test_description():
             "headless": "true",
             "rviz": "false",
             "use_sim_time": "true",
+            "render_sensors": "false",
             "world": os.path.join(package_share, "worlds", "empty.world"),
             "motion_profile": motion_profile,
             # This test pins the divergence between commanded and achieved

--- a/yahboom_rosmaster_gazebo/test/sensor_contract.launch.py
+++ b/yahboom_rosmaster_gazebo/test/sensor_contract.launch.py
@@ -14,6 +14,7 @@ from launch.actions import (
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
 import launch_testing
 import launch_testing.actions
 import launch_testing.asserts
@@ -25,6 +26,8 @@ import unittest
 def generate_test_description():
     package_share = get_package_share_directory("yahboom_rosmaster_gazebo")
     world = LaunchConfiguration("world")
+    samples = LaunchConfiguration("samples")
+    performance_checks = LaunchConfiguration("performance_checks")
     simulator = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(package_share, "launch", "rosmaster_gazebo_fortress.launch.py")
@@ -39,12 +42,19 @@ def generate_test_description():
     probe = Node(
         package="yahboom_rosmaster_gazebo",
         executable="sensor_contract_probe.py",
-        parameters=[{"timeout": 45.0, "samples": 10}],
+        parameters=[{
+            "timeout": 45.0,
+            "samples": ParameterValue(samples, value_type=int),
+            "performance_checks": ParameterValue(
+                performance_checks, value_type=bool),
+        }],
         output="screen",
     )
 
     return LaunchDescription([
         DeclareLaunchArgument("world", default_value="empty.world"),
+        DeclareLaunchArgument("samples", default_value="10"),
+        DeclareLaunchArgument("performance_checks", default_value="true"),
         SetEnvironmentVariable(
             "IGN_PARTITION", f"yahboom_sensor_contract_{os.getpid()}"),
         # Keep sequential world tests isolated even when their PIDs differ by a

--- a/yahboom_rosmaster_gazebo/test/sensor_contract_probe_test.py
+++ b/yahboom_rosmaster_gazebo/test/sensor_contract_probe_test.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Regression tests for strict evidence and CI TF sample buffering."""
+
+from collections import deque
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+import unittest
+
+
+PROBE_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "sensor_contract_probe.py"
+)
+PROBE_SPEC = importlib.util.spec_from_file_location(
+    "sensor_contract_probe", PROBE_PATH)
+PROBE_MODULE = importlib.util.module_from_spec(PROBE_SPEC)
+PROBE_SPEC.loader.exec_module(PROBE_MODULE)
+
+
+class TestSensorContractBuffering(unittest.TestCase):
+    """Keep primary evidence immutable while CI TF samples stay recent."""
+
+    @staticmethod
+    def make_probe(performance_checks):
+        """Return the capture state needed by the probe's callback."""
+        return SimpleNamespace(
+            first_arrivals={},
+            observed_dynamic_tf_edges=set(),
+            messages={"/odom": []},
+            recent_tf_messages={"/odom": deque(maxlen=3)},
+            required_counts={"/odom": 3},
+            performance_checks=performance_checks,
+        )
+
+    @staticmethod
+    def capture(probe):
+        """Feed five distinguishable odometry placeholders to a probe."""
+        for value in range(5):
+            PROBE_MODULE.SensorContractProbe.capture(probe, "/odom", value)
+
+    def test_primary_messages_remain_first_samples_in_both_modes(self):
+        """Later valid samples must never overwrite initial contract evidence."""
+        for performance_checks in (True, False):
+            with self.subTest(performance_checks=performance_checks):
+                probe = self.make_probe(performance_checks)
+                self.capture(probe)
+                self.assertEqual(probe.messages["/odom"], [0, 1, 2])
+
+    def test_correctness_mode_keeps_separate_recent_tf_samples(self):
+        """CI exact-time TF validation should use its bounded recent window."""
+        probe = self.make_probe(False)
+        self.capture(probe)
+        self.assertEqual(list(probe.recent_tf_messages["/odom"]), [2, 3, 4])
+
+    def test_sample_count_supports_third_from_last_lookup(self):
+        """Requested counts below three must be clamped to three."""
+        self.assertEqual(PROBE_MODULE.validated_sample_count(0), 3)
+        self.assertEqual(PROBE_MODULE.validated_sample_count(2), 3)
+        self.assertEqual(PROBE_MODULE.validated_sample_count(3), 3)
+        self.assertEqual(PROBE_MODULE.validated_sample_count(10), 10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/yahboom_rosmaster_gazebo/test/world_smoke.launch.py
+++ b/yahboom_rosmaster_gazebo/test/world_smoke.launch.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Launch a practice world headless and require the spawn smoke contract to pass."""
+"""Launch a practice world headless and require its smoke contract to pass."""
 
 import os
 
@@ -7,10 +7,16 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import (
     DeclareLaunchArgument,
+    EmitEvent,
+    ExecuteProcess,
     IncludeLaunchDescription,
+    LogInfo,
+    RegisterEventHandler,
     SetEnvironmentVariable,
     TimerAction,
 )
+from launch.event_handlers import OnProcessExit
+from launch.events import Shutdown
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
@@ -21,13 +27,40 @@ import pytest
 import unittest
 
 
+GROUND_TRUTH_READY_TIMEOUT = 20.0
+
+
+def _start_probe_after_ground_truth(
+        event, context, probe, readiness_timeout):
+    """Start the probe after the simulator publishes robot pose."""
+    readiness_timeout.cancel()
+    # A timeout-triggered launch shutdown can make the readiness process exit
+    # while this handler is still registered. Never start the probe during
+    # teardown or emit a redundant Shutdown event.
+    if context.is_shutdown:
+        return []
+    if event.returncode != 0:
+        return [EmitEvent(event=Shutdown(
+            reason=(
+                "ground-truth readiness process exited with code "
+                f"{event.returncode} before the smoke probe could start"
+            ),
+        ))]
+    return [
+        LogInfo(
+            msg="Ground truth is publishing; starting the world smoke probe"),
+        probe,
+    ]
+
+
 @pytest.mark.launch_test
 def generate_test_description():
     package_share = get_package_share_directory("yahboom_rosmaster_gazebo")
     world = LaunchConfiguration("world")
     simulator = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            os.path.join(package_share, "launch", "rosmaster_gazebo_fortress.launch.py")
+            os.path.join(
+                package_share, "launch", "rosmaster_gazebo_fortress.launch.py")
         ),
         launch_arguments={
             "headless": "true",
@@ -37,7 +70,7 @@ def generate_test_description():
             # The probe commands a short forward move to confirm the world
             # doesn't block translation (world_smoke_probe.py checks this
             # against a fixed meaningful_motion distance), so the /cmd_vel
-            # motion bias -- resampled at random per launch -- must be off.
+            # motion bias, resampled at random per launch, must be off.
             "motion_bias": "false",
         }.items(),
     )
@@ -53,6 +86,43 @@ def generate_test_description():
         }],
         output="screen",
     )
+    # Start listening before the simulator so the probe is launched on the
+    # first bridged robot-pose sample instead of after an assumed wall-clock
+    # startup duration. Ground truth is emitted only after Gazebo has spawned
+    # the robot and the bridge is active; the probe itself then owns the richer
+    # settle/interface checks.
+    ground_truth_ready = ExecuteProcess(
+        cmd=[
+            "ros2", "topic", "echo",
+            "--once",
+            "--no-daemon",
+            "--qos-reliability", "best_effort",
+            "--field", "header.stamp",
+            "/ground_truth/odom", "nav_msgs/msg/Odometry",
+        ],
+        name="wait_for_ground_truth",
+        output="screen",
+    )
+    # Bound the readiness gate before the active test's 30-second startup wait.
+    # Together with the probe's 32-second budget, this leaves 18 seconds inside
+    # each CTest target's 70-second limit for launch and simulator teardown.
+    readiness_timeout = TimerAction(
+        period=GROUND_TRUTH_READY_TIMEOUT,
+        actions=[
+            LogInfo(msg=(
+                "Timed out waiting for /ground_truth/odom; "
+                "shutting down the world smoke test")),
+            EmitEvent(event=Shutdown(
+                reason=(
+                    "ground truth did not become ready within "
+                    f"{GROUND_TRUTH_READY_TIMEOUT:.0f} seconds"))),
+        ],
+    )
+    start_probe_when_ready = RegisterEventHandler(OnProcessExit(
+        target_action=ground_truth_ready,
+        on_exit=lambda event, context: _start_probe_after_ground_truth(
+            event, context, probe, readiness_timeout),
+    ))
 
     return LaunchDescription([
         DeclareLaunchArgument("world", default_value="empty.world"),
@@ -61,14 +131,16 @@ def generate_test_description():
         # Keep sequential world tests isolated even when their PIDs differ by a
         # round multiple of 100 (a pattern observed under CTest).
         SetEnvironmentVariable("ROS_DOMAIN_ID", str(10 + os.getpid() % 211)),
+        start_probe_when_ready,
+        readiness_timeout,
+        ground_truth_ready,
         simulator,
-        TimerAction(period=15.0, actions=[probe]),
         launch_testing.actions.ReadyToTest(),
     ]), {"probe": probe}
 
 
 class TestWorldSmoke(unittest.TestCase):
-    """Require the spawn smoke probe to finish successfully within the launch-test budget."""
+    """Require the probe to finish within the launch-test budget."""
 
     def test_probe_passes(self, proc_info, probe):
         proc_info.assertWaitForStartup(probe, timeout=30)

--- a/yahboom_rosmaster_gazebo/test/world_smoke_probe_test.py
+++ b/yahboom_rosmaster_gazebo/test/world_smoke_probe_test.py
@@ -2,6 +2,7 @@
 """Focused unit tests for the practice-world smoke probe."""
 
 from pathlib import Path
+import math
 import sys
 import unittest
 from unittest.mock import patch
@@ -17,13 +18,16 @@ import world_smoke_probe  # noqa: E402
 from world_smoke_probe import WorldSmokeProbe, stamp_seconds  # noqa: E402
 
 
-def odometry(stamp, x=0.0):
-    """Build a level ground-truth sample at a requested time and x position."""
+def odometry(stamp, x=0.0, y=0.0, z=0.0, yaw=0.0):
+    """Build a level ground-truth sample at a requested pose and time."""
     message = Odometry()
     message.header.stamp.sec = int(stamp)
     message.header.stamp.nanosec = int((stamp - int(stamp)) * 1e9)
     message.pose.pose.position.x = x
-    message.pose.pose.orientation.w = 1.0
+    message.pose.pose.position.y = y
+    message.pose.pose.position.z = z
+    message.pose.pose.orientation.z = math.sin(yaw / 2.0)
+    message.pose.pose.orientation.w = math.cos(yaw / 2.0)
     return message
 
 
@@ -69,6 +73,17 @@ class TestWorldSmokeProbe(unittest.TestCase):
         errors = self.probe.validate()
 
         self.assertTrue(any("expected (0, 0) spawn point" in error for error in errors))
+
+    def test_validate_rejects_out_and_back_spawn_excursion(self):
+        self.probe.ground_truth = [
+            odometry(0.0),
+            odometry(1.5, x=0.08),
+            odometry(3.0),
+        ]
+
+        errors = self.probe.validate()
+
+        self.assertTrue(any("maximum excursion" in error for error in errors))
 
     def test_motion_requires_full_simulation_time_window(self):
         start = odometry(0.0)
@@ -120,6 +135,40 @@ class TestWorldSmokeProbe(unittest.TestCase):
         errors = self.probe.validate_motion(start, end, command_elapsed=2.0)
 
         self.assertTrue(any("wheels may be spinning" in error for error in errors))
+
+    def test_motion_rejects_backward_displacement(self):
+        start = odometry(0.0)
+        end = odometry(2.0, x=-0.20)
+
+        errors = self.probe.validate_motion(start, end, command_elapsed=2.0)
+
+        self.assertTrue(any("backward" in error for error in errors))
+
+    def test_motion_reports_small_negative_displacement_as_backward(self):
+        start = odometry(0.0)
+        end = odometry(2.0, x=-0.02)
+
+        errors = self.probe.validate_motion(start, end, command_elapsed=2.0)
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("moved 0.020m backward", errors[0])
+        self.assertNotIn("-0.020m forward", errors[0])
+
+    def test_motion_rejects_lateral_displacement(self):
+        start = odometry(0.0)
+        end = odometry(2.0, y=0.20)
+
+        errors = self.probe.validate_motion(start, end, command_elapsed=2.0)
+
+        self.assertTrue(any("laterally" in error for error in errors))
+
+    def test_motion_projects_displacement_onto_initial_yaw(self):
+        start = odometry(0.0, yaw=math.pi / 2.0)
+        end = odometry(2.0, y=0.20, yaw=0.0)
+
+        errors = self.probe.validate_motion(start, end, command_elapsed=2.0)
+
+        self.assertEqual(errors, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Reviewer guide

**Merge 1 of 2.** This is the first PR the external reviewer should approve and
merge. It combines the simulator contract-stability work formerly reviewed as
#25 with the headless CI gate from this PR.

The three commits are intentionally ordered:

1. `a41d09a` — harden practice-world readiness, motion, settle, and teardown
   contracts;
2. `9e9e064` — add the representative headless simulator CI workflow;
3. `6e53c4f` — stabilize the hosted sensor and Gazebo shutdown behavior exposed
   by the first hosted run.

After this PR merges, repository administration can require the
`ROS 2 Humble / Gazebo Fortress` status. Then #26 is retargeted to `main` and
reviewed as **merge 2 of 2**.

This PR supersedes #25. It deliberately excludes wheel geometry (#26) and the
unfinished SLAM-aware ground-truth display alignment formerly bundled in #11.

Closes #12.

## Contract stability

The practice-world smoke tests previously relied on a fixed startup delay,
accepted motion in the wrong direction, and could miss out-and-back movement
during the settle window. Gazebo could also stop before the image bridge,
creating an intermittent teardown crash.

This PR:

- starts smoke validation from the first `/ground_truth/odom` sample, with a
  bounded readiness timeout;
- projects motion into the initial robot heading and requires predominantly
  forward travel;
- measures maximum uncommanded excursion across the complete settle window;
- stops the image bridge before Gazebo sensor shutdown;
- adds focused unit coverage for readiness, direction, excursion, shutdown
  ordering, timeout fallback, and platforms without `/proc`.

## Representative CI gate

The workflow runs these ten targets sequentially:

- `robot_description_contract`
- `motion_profile_contract`
- `practice_world_probe_contract`
- `launch_shutdown_contract`
- `sensor_contract_probe_contract`
- `sensor_contract_ci`
- `base_feedback`
- `ground_truth_contract`
- `motion_profile_divergence_ideal`
- `wheel_odometry_resilience`

The regex also reserves `motion_profile_yaw_ideal`, which becomes active after
#26 lands.

`sensor_contract_ci` requires every public topic, valid payloads and frames,
increasing timestamps, a dynamic TF edge, and exact timestamped-TF
connectivity. Nominal frequency and first-arrival latency remain in the strict
local `sensor_contract_empty` and `sensor_contract_cafe` targets so hosted
runner load does not masquerade as a simulator regression. Their thresholds
are unchanged.

The cafe sensor run, stress profile, detailed depth/LiDAR/IMU contracts, eight
individual practice-world smoke tests, and complete lint suite remain part of
the documented full local validation.

## Hosted runner and teardown behavior

- Ubuntu 22.04 in `ros:humble-ros-base-jammy`, with Gazebo Fortress major
  version 6 verified.
- Xvfb and llvmpipe software rendering with a 2 GiB shared-memory budget.
- Packages and CTest targets run sequentially.
- Rendering-only image and point-cloud bridges follow `render_sensors`.
- Contracts that do not consume LiDAR/RGB-D disable rendered sensors.
- An acknowledged Gazebo stop receives a bounded ten-second grace period
  before signal fallback, avoiding a second signal while Fortress joins its
  sensor thread.
- Failures still propagate while full CTest/colcon results are printed.
- Superseded runs for the same PR are cancelled.
- Repository permissions are read-only and actions are pinned immutably.
- Failure diagnostics are retained for 14 days; successful runs create no
  artifact.

## Validation

Contract-stability validation before CI extraction:

- Maze 3 regression soak: **20/20 passed**.
- All practice worlds: **8/8 passed**.
- Empty and cafe sensor contracts: **2/2 passed**.
- Stability result tree: **52 tests, 0 failures**.
- No image-bridge crash, teardown error signature, or orphan process.

Final branch validation:

- All five supported simulator packages build successfully.
- Representative local gate: **10/10 targets passed** in **2m04s**.
- Available local result tree: **71 tests, 0 errors, 0 failures**.
- Strict `sensor_contract_empty` and hosted-style `sensor_contract_ci` pass.
- Shutdown, buffering, Flake8, PEP 257, CMake lint, shell syntax, workflow
  structure, trigger assertions, rosdep simulation, and whitespace checks
  pass.
- No simulator processes remain after the runs.
- Hosted soak on `6e53c4f`: **3/3 consecutive attempts passed** — **4m47s**,
  **4m39s**, and **4m38s** total; representative contracts took **1m35s**,
  **1m28s**, and **1m32s**. All attempts had zero annotations and no failure
  artifact. See
  [run 33460672001](https://github.com/AIRclub-UdeSA/yahboom_rosmaster/actions/runs/33460672001).

The hosted soak used manual dispatch on this exact head because the workflow
does not exist on `main` until this PR merges.

## Risk and rollout

- Stricter smoke criteria can expose real world or motion instability that the
  older checks overlooked.
- Startup now fails explicitly if ground truth remains unavailable after the
  bounded readiness budget.
- Hosted sensor correctness remains strict while hardware-speed assertions are
  intentionally kept in the local performance contracts.

After merge, add `ROS 2 Humble / Gazebo Fortress` to the `main` ruleset's
required checks. Do not require it before this workflow reaches `main`.
