### PR TITLE
Add _victimas variants to the four remaining maze worlds

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ ros2 launch yahboom_rosmaster_bringup rosmaster_x3_sim.launch.py \
 | `maze_2_6x5.world` | plywood_mazes maze 2, 6x5 m | `world_smoke_maze_2` |
 | `maze_2_6x5_victimas.world` | `maze_2_6x5.world` layout plus five color-marker obstacle cubes (three red, two blue; 0.25x0.25x0.3 m) tucked into narrow passages for camera/LiDAR color-detection workshops | `world_smoke_maze_2_victimas` |
 | `maze_3_6x6.world` | plywood_mazes maze 3, 6x6 m | `world_smoke_maze_3` |
+| `maze_3_6x6_victimas.world` | `maze_3_6x6.world` layout plus five color-marker obstacle cubes (three red, two blue; 0.25x0.25x0.3 m) tucked into narrow passages for camera/LiDAR color-detection workshops | `world_smoke_maze_3_victimas` |
 | `maze_4_metal_6x6.world` | plywood_mazes maze 4, metal panels, 6x6 m | `world_smoke_maze_4` |
 
 Walls are 0.5 m tall in all eight -- clear of the LiDAR (0.11 m) and camera

--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ ros2 launch yahboom_rosmaster_bringup rosmaster_x3_sim.launch.py \
 | `laberinto_1.world` | Larger, more convoluted maze exported from Gazebo's Building Editor | `world_smoke_laberinto_1` |
 | `laberinto_1_victimas.world` | `laberinto_1.world` layout plus four color-marker obstacle cubes (three red, one blue; 0.25x0.25x0.3 m, one shrunk to 0.15x0.15x0.3 m to fit a ~0.31 m gap between two walls) tucked into narrow passages -- diagonal column corridor, small side room, stub-wall zigzag, and a wall gap -- so the robot has to enter a corridor before it can see and identify the color | `world_smoke_laberinto_1_victimas` |
 | `maze_1_6x5.world` | plywood_mazes maze 1, 6x5 m | `world_smoke_maze_1` |
+| `maze_1_6x5_victimas.world` | `maze_1_6x5.world` layout plus four color-marker obstacle cubes (two red, two blue; 0.25x0.25x0.3 m) tucked into narrow passages for camera/LiDAR color-detection workshops | `world_smoke_maze_1_victimas` |
 | `maze_2_6x5.world` | plywood_mazes maze 2, 6x5 m | `world_smoke_maze_2` |
 | `maze_3_6x6.world` | plywood_mazes maze 3, 6x6 m | `world_smoke_maze_3` |
 | `maze_4_metal_6x6.world` | plywood_mazes maze 4, metal panels, 6x6 m | `world_smoke_maze_4` |

--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ ros2 launch yahboom_rosmaster_bringup rosmaster_x3_sim.launch.py \
 | `maze_1_6x5.world` | plywood_mazes maze 1, 6x5 m | `world_smoke_maze_1` |
 | `maze_1_6x5_victimas.world` | `maze_1_6x5.world` layout plus four color-marker obstacle cubes (two red, two blue; 0.25x0.25x0.3 m) tucked into narrow passages for camera/LiDAR color-detection workshops | `world_smoke_maze_1_victimas` |
 | `maze_2_6x5.world` | plywood_mazes maze 2, 6x5 m | `world_smoke_maze_2` |
+| `maze_2_6x5_victimas.world` | `maze_2_6x5.world` layout plus five color-marker obstacle cubes (three red, two blue; 0.25x0.25x0.3 m) tucked into narrow passages for camera/LiDAR color-detection workshops | `world_smoke_maze_2_victimas` |
 | `maze_3_6x6.world` | plywood_mazes maze 3, 6x6 m | `world_smoke_maze_3` |
 | `maze_4_metal_6x6.world` | plywood_mazes maze 4, metal panels, 6x6 m | `world_smoke_maze_4` |
 

--- a/README.md
+++ b/README.md
@@ -287,8 +287,8 @@ ros2 launch yahboom_rosmaster_bringup rosmaster_x3_sim.launch.py \
 
 ### Maze Worlds
 
-The repository also ships eight maze worlds for practice and competition
-runs -- four authored for this project and four imported from
+The repository also ships twelve maze worlds for practice and competition
+runs -- four authored for this project and eight imported from
 [plywood_mazes](https://github.com/rfzeg/plywood_mazes). They launch the
 same way as the cafe world; a bare file name resolves inside `worlds/`:
 
@@ -312,7 +312,7 @@ ros2 launch yahboom_rosmaster_bringup rosmaster_x3_sim.launch.py \
 | `maze_4_metal_6x6.world` | plywood_mazes maze 4, metal panels, 6x6 m | `world_smoke_maze_4` |
 | `maze_4_metal_6x6_victimas.world` | `maze_4_metal_6x6.world` layout plus four color-marker obstacle cubes (two red, two blue; 0.25x0.25x0.3 m) tucked into narrow passages for camera/LiDAR color-detection workshops | `world_smoke_maze_4_victimas` |
 
-Walls are 0.5 m tall in all eight -- clear of the LiDAR (0.11 m) and camera
+Walls are 0.5 m tall in all twelve -- clear of the LiDAR (0.11 m) and camera
 (0.05 m) mount heights, but low enough to inspect the layout from the
 Gazebo GUI.
 
@@ -537,7 +537,7 @@ colcon test --packages-select yahboom_rosmaster_gazebo \
 colcon test-result --verbose
 ```
 
-The eight maze/practice worlds are covered separately by the lighter
+The twelve maze/practice worlds are covered separately by the lighter
 `world_smoke_*` tests (spawn validity, initial collisions, a forward-motion
 check, core topics -- see "Maze Worlds" above), so they are not part of the
 regex above:
@@ -663,7 +663,7 @@ stress profile creates measurable wheel-odometry divergence while the optional
 ideal profile preserves the previous near-zero-error baseline. Automated headless
 contracts cover both supported worlds, and isolated acceptance tests exercise
 controlled RGB-D/LiDAR geometry, IMU motion, wheel signs, odometry, ground
-truth, profile selection, and TF. The eight maze/practice worlds each get a
+truth, profile selection, and TF. The twelve maze/practice worlds each get a
 lighter `world_smoke_*` launch test covering spawn validity, initial
 collisions, a forward-motion check, and core topic liveness -- see "Maze
 Worlds" above.
@@ -690,10 +690,12 @@ The following simulator limitations remain:
   measured covariance.
 - `simple_room.world` and `willowgarage.world` are retained migration assets;
   they are deliberately not supported Fortress worlds and are excluded from
-  automated coverage, unlike the eight maze worlds below.
-- The eight maze worlds (`laberinto_simple.world`, `laberinto_simple_victimas.world`,
+  automated coverage, unlike the twelve maze worlds below.
+- The twelve maze worlds (`laberinto_simple.world`, `laberinto_simple_victimas.world`,
   `laberinto_1.world`, `laberinto_1_victimas.world`, `maze_1_6x5.world`,
-  `maze_2_6x5.world`, `maze_3_6x6.world`, `maze_4_metal_6x6.world`) each have
+  `maze_1_6x5_victimas.world`, `maze_2_6x5.world`, `maze_2_6x5_victimas.world`,
+  `maze_3_6x6.world`, `maze_3_6x6_victimas.world`, `maze_4_metal_6x6.world`,
+  `maze_4_metal_6x6_victimas.world`) each have
   a `world_smoke_*` launch test (spawn validity, no initial collision, a
   forward-motion check, core topics) but not the full rate/message-shape
   contract that the empty and cafe worlds get -- see the "Maze Worlds"
@@ -701,9 +703,11 @@ The following simulator limitations remain:
   map (`maps/laberinto_simple.yaml`); the others have no pre-built map.
   `maze_3_6x6.world`'s map was removed -- it no longer matched the world
   after the maze offset changed in #10, and needs to be re-captured (see
-  #15). The obstacle cubes in `laberinto_simple_victimas.world` and
-  `laberinto_1_victimas.world` have collision but are not part of any map
-  either -- they are meant to be detected live via camera/LiDAR, not
+  #15). The obstacle cubes in `laberinto_simple_victimas.world`,
+  `laberinto_1_victimas.world`, `maze_1_6x5_victimas.world`,
+  `maze_2_6x5_victimas.world`, `maze_3_6x6_victimas.world`, and
+  `maze_4_metal_6x6_victimas.world` have collision but are not part of any
+  map either -- they are meant to be detected live via camera/LiDAR, not
   pre-mapped.
 - Multi-robot operation and real-hardware bringup are not provided.
 

--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ ros2 launch yahboom_rosmaster_bringup rosmaster_x3_sim.launch.py \
 | `maze_3_6x6.world` | plywood_mazes maze 3, 6x6 m | `world_smoke_maze_3` |
 | `maze_3_6x6_victimas.world` | `maze_3_6x6.world` layout plus five color-marker obstacle cubes (three red, two blue; 0.25x0.25x0.3 m) tucked into narrow passages for camera/LiDAR color-detection workshops | `world_smoke_maze_3_victimas` |
 | `maze_4_metal_6x6.world` | plywood_mazes maze 4, metal panels, 6x6 m | `world_smoke_maze_4` |
+| `maze_4_metal_6x6_victimas.world` | `maze_4_metal_6x6.world` layout plus four color-marker obstacle cubes (two red, two blue; 0.25x0.25x0.3 m) tucked into narrow passages for camera/LiDAR color-detection workshops | `world_smoke_maze_4_victimas` |
 
 Walls are 0.5 m tall in all eight -- clear of the LiDAR (0.11 m) and camera
 (0.05 m) mount heights, but low enough to inspect the layout from the

--- a/yahboom_rosmaster_gazebo/CMakeLists.txt
+++ b/yahboom_rosmaster_gazebo/CMakeLists.txt
@@ -142,6 +142,12 @@ if(BUILD_TESTING)
   )
   add_launch_test(
     test/world_smoke.launch.py
+    TARGET world_smoke_maze_1_victimas
+    TIMEOUT 70
+    ARGS "world:=maze_1_6x5_victimas.world"
+  )
+  add_launch_test(
+    test/world_smoke.launch.py
     TARGET world_smoke_maze_2
     TIMEOUT 70
     ARGS "world:=maze_2_6x5.world"

--- a/yahboom_rosmaster_gazebo/CMakeLists.txt
+++ b/yahboom_rosmaster_gazebo/CMakeLists.txt
@@ -166,6 +166,12 @@ if(BUILD_TESTING)
   )
   add_launch_test(
     test/world_smoke.launch.py
+    TARGET world_smoke_maze_3_victimas
+    TIMEOUT 70
+    ARGS "world:=maze_3_6x6_victimas.world"
+  )
+  add_launch_test(
+    test/world_smoke.launch.py
     TARGET world_smoke_maze_4
     TIMEOUT 70
     ARGS "world:=maze_4_metal_6x6.world"

--- a/yahboom_rosmaster_gazebo/CMakeLists.txt
+++ b/yahboom_rosmaster_gazebo/CMakeLists.txt
@@ -154,6 +154,12 @@ if(BUILD_TESTING)
   )
   add_launch_test(
     test/world_smoke.launch.py
+    TARGET world_smoke_maze_2_victimas
+    TIMEOUT 70
+    ARGS "world:=maze_2_6x5_victimas.world"
+  )
+  add_launch_test(
+    test/world_smoke.launch.py
     TARGET world_smoke_maze_3
     TIMEOUT 70
     ARGS "world:=maze_3_6x6.world"

--- a/yahboom_rosmaster_gazebo/CMakeLists.txt
+++ b/yahboom_rosmaster_gazebo/CMakeLists.txt
@@ -176,6 +176,12 @@ if(BUILD_TESTING)
     TIMEOUT 70
     ARGS "world:=maze_4_metal_6x6.world"
   )
+  add_launch_test(
+    test/world_smoke.launch.py
+    TARGET world_smoke_maze_4_victimas
+    TIMEOUT 70
+    ARGS "world:=maze_4_metal_6x6_victimas.world"
+  )
 endif()
 
 ament_package()

--- a/yahboom_rosmaster_gazebo/worlds/maze_1_6x5_victimas.world
+++ b/yahboom_rosmaster_gazebo/worlds/maze_1_6x5_victimas.world
@@ -1,0 +1,204 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <world name="maze_6x5_v1_victimas">
+
+    <physics type="ode">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>1000</real_time_update_rate>
+      <gravity>0 0 -9.8</gravity>
+      <!--   <gravity>0 0 0</gravity> -->
+    </physics>
+
+    <plugin filename="gz-sim-physics-system"
+            name="gz::sim::systems::Physics"/>
+    <plugin filename="gz-sim-user-commands-system"
+            name="gz::sim::systems::UserCommands"/>
+    <plugin filename="gz-sim-scene-broadcaster-system"
+            name="gz::sim::systems::SceneBroadcaster"/>
+    <plugin filename="gz-sim-contact-system"
+            name="gz::sim::systems::Contact"/>
+    <plugin filename="gz-sim-sensors-system"
+            name="gz::sim::systems::Sensors">
+      <render_engine>ogre2</render_engine>
+    </plugin>
+    <plugin filename="gz-sim-imu-system"
+            name="gz::sim::systems::Imu"/>
+
+    <!-- Disable shadows, disable grid -->
+    <scene>
+      <shadows>false</shadows>
+      <ambient>0.2 0.2 0.2 1</ambient>
+      <background>1 1 1 1</background>
+      <grid>false</grid>
+      <origin_visual>false</origin_visual>
+    </scene>
+
+    <!-- A global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <!-- A directed light source -->
+    <light name="camera_spot_1_light" type='spot'>
+      <pose>-6 4 4 0 -1 -0.8</pose>
+      <diffuse>0.5 0.5 0.5 1</diffuse>
+      <specular>0.1 0.1 0.1 1</specular>
+      <direction>0 0 -1</direction>
+      <attenuation>
+        <range>20</range>
+        <constant>0.2</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <cast_shadows>0</cast_shadows>
+      <spot>
+        <inner_angle>0.6</inner_angle>
+        <outer_angle>1</outer_angle>
+        <falloff>1</falloff>
+      </spot>
+    </light>
+
+    <!-- A second directed light source -->
+    <light name="camera_spot_2_light" type='spot'>
+      <pose>5 -3 4 0 0.8 -0.6</pose>
+      <diffuse>0.5 0.5 0.5 1</diffuse>
+      <specular>0.1 0.1 0.1 1</specular>
+      <direction>0 0 -1</direction>
+      <attenuation>
+        <range>20</range>
+        <constant>0.3</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <cast_shadows>0</cast_shadows>
+      <spot>
+        <inner_angle>0.6</inner_angle>
+        <outer_angle>1</outer_angle>
+        <falloff>1</falloff>
+      </spot>
+    </light>
+
+    <!-- A wooden parquet ground plane -->
+    <!-- Centered on the maze's world-frame bounding box (x:[-1.5,4.5], y:[-3.5,1.5]) -->
+    <include>
+      <uri>model://floor_parquet2</uri>
+      <pose>1.5 -1.0 0 0 0 0</pose>
+    </include>
+
+    <!-- A maze made of plywood panels -->
+    <!-- Offset chosen so the robot spawn point (world 0,0) lands in the fully
+         open pass-through cell at local (1.5, 3.5) instead of inside a wall. -->
+    <include>
+      <uri>model://maze_1_6x5</uri>
+      <pose>-1.5 -3.5 0 0 0 0</pose>
+    </include>
+
+    <!-- A set of tag36h11 AprilTags -->
+    <include>
+      <uri>model://maze_1_tags</uri>
+      <pose>-1.5 -3.5 0 0 0 0</pose>
+    </include>
+
+    <!-- Marcas de color: cubos con colision real (tambien son un obstaculo
+         fisico), ubicados en pasajes angostos verificados en el GUI de
+         Gazebo para que no queden a la vista desde el spawn. Posiciones
+         en coordenadas de mundo (no locales al maze). -->
+    <model name='marcas_color'>
+      <static>1</static>
+
+      <link name='cuadrado_rojo_1'>
+        <pose>-0.1698 -2.0228 0.15 0 0 0</pose>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.05 0.05 1</ambient>
+            <diffuse>0.8 0.05 0.05 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <link name='cuadrado_azul_1'>
+        <pose>2.0594 -1.0174 0.15 0 0 0</pose>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.05 0.05 0.8 1</ambient>
+            <diffuse>0.05 0.05 0.8 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <link name='cuadrado_rojo_2'>
+        <pose>2.0734 -2.0864 0.15 0 0 0</pose>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.05 0.05 1</ambient>
+            <diffuse>0.8 0.05 0.05 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <link name='cuadrado_azul_2'>
+        <pose>3.9811 0.9197 0.15 0 0 0</pose>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.05 0.05 0.8 1</ambient>
+            <diffuse>0.05 0.05 0.8 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+  </world>
+</sdf>

--- a/yahboom_rosmaster_gazebo/worlds/maze_2_6x5_victimas.world
+++ b/yahboom_rosmaster_gazebo/worlds/maze_2_6x5_victimas.world
@@ -1,0 +1,227 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <world name="maze_6x5_v2_victimas">
+
+    <physics type="ode">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>1000</real_time_update_rate>
+      <gravity>0 0 -9.8</gravity>
+      <!--   <gravity>0 0 0</gravity> -->
+    </physics>
+
+    <plugin filename="gz-sim-physics-system"
+            name="gz::sim::systems::Physics"/>
+    <plugin filename="gz-sim-user-commands-system"
+            name="gz::sim::systems::UserCommands"/>
+    <plugin filename="gz-sim-scene-broadcaster-system"
+            name="gz::sim::systems::SceneBroadcaster"/>
+    <plugin filename="gz-sim-contact-system"
+            name="gz::sim::systems::Contact"/>
+    <plugin filename="gz-sim-sensors-system"
+            name="gz::sim::systems::Sensors">
+      <render_engine>ogre2</render_engine>
+    </plugin>
+    <plugin filename="gz-sim-imu-system"
+            name="gz::sim::systems::Imu"/>
+
+    <!-- Disable shadows, disable grid -->
+    <scene>
+      <shadows>false</shadows>
+      <ambient>0.2 0.2 0.2 1</ambient>
+      <background>1 1 1 1</background>
+      <grid>false</grid>
+      <origin_visual>false</origin_visual>
+    </scene>
+
+    <!-- A global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <!-- A directed light source -->
+    <light name="camera_spot_1_light" type='spot'>
+      <pose>-6 4 4 0 -1 -0.8</pose>
+      <diffuse>0.5 0.5 0.5 1</diffuse>
+      <specular>0.1 0.1 0.1 1</specular>
+      <direction>0 0 -1</direction>
+      <attenuation>
+        <range>20</range>
+        <constant>0.2</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <cast_shadows>0</cast_shadows>
+      <spot>
+        <inner_angle>0.6</inner_angle>
+        <outer_angle>1</outer_angle>
+        <falloff>1</falloff>
+      </spot>
+    </light>
+
+    <!-- A second directed light source -->
+    <light name="camera_spot_2_light" type='spot'>
+      <pose>5 -3 4 0 0.8 -0.6</pose>
+      <diffuse>0.5 0.5 0.5 1</diffuse>
+      <specular>0.1 0.1 0.1 1</specular>
+      <direction>0 0 -1</direction>
+      <attenuation>
+        <range>20</range>
+        <constant>0.3</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <cast_shadows>0</cast_shadows>
+      <spot>
+        <inner_angle>0.6</inner_angle>
+        <outer_angle>1</outer_angle>
+        <falloff>1</falloff>
+      </spot>
+    </light>
+
+    <!-- A wooden parquet ground plane -->
+    <!-- Centered on the maze's world-frame bounding box (x:[-1.5,4.5], y:[-3.5,1.5]) -->
+    <include>
+      <uri>model://floor_parquet2</uri>
+      <pose>1.5 -1.0 0 0 0 0</pose>
+    </include>
+
+    <!-- A maze made of plywood panels -->
+    <!-- Offset chosen so the robot spawn point (world 0,0) lands in the fully
+         open pass-through cell at local (1.5, 3.5) instead of inside a wall. -->
+    <include>
+      <uri>model://maze_2_6x5</uri>
+      <pose>-1.5 -3.5 0 0 0 0</pose>
+    </include>
+
+    <!-- A set of tag36h11 AprilTags -->
+    <include>
+      <uri>model://maze_2_tags</uri>
+      <pose>-1.5 -3.5 0 0 0 0</pose>
+    </include>
+
+    <!-- Marcas de color: cubos con colision real (tambien son un obstaculo
+         fisico), ubicados en pasajes angostos verificados en el GUI de
+         Gazebo para que no queden a la vista desde el spawn. Posiciones
+         en coordenadas de mundo (no locales al maze). -->
+    <model name='marcas_color'>
+      <static>1</static>
+
+      <link name='cuadrado_rojo_1'>
+        <pose>1.0308 -1.8959 0.15 0 0 0</pose>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.05 0.05 1</ambient>
+            <diffuse>0.8 0.05 0.05 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <link name='cuadrado_azul_1'>
+        <pose>3.0479 -1.9360 0.15 0 0 0</pose>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.05 0.05 0.8 1</ambient>
+            <diffuse>0.05 0.05 0.8 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <link name='cuadrado_rojo_2'>
+        <pose>2.9884 -0.9984 0.15 0 0 0</pose>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.05 0.05 1</ambient>
+            <diffuse>0.8 0.05 0.05 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <link name='cuadrado_azul_2'>
+        <pose>-0.9657 -2.0783 0.15 0 0 0</pose>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.05 0.05 0.8 1</ambient>
+            <diffuse>0.05 0.05 0.8 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <link name='cuadrado_rojo_3'>
+        <pose>-0.9077 0.9429 0.15 0 0 0</pose>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.05 0.05 1</ambient>
+            <diffuse>0.8 0.05 0.05 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+  </world>
+</sdf>

--- a/yahboom_rosmaster_gazebo/worlds/maze_3_6x6_victimas.world
+++ b/yahboom_rosmaster_gazebo/worlds/maze_3_6x6_victimas.world
@@ -1,0 +1,241 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <world name="maze_6x6_v1_victimas">
+
+    <physics type="ode">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>1000</real_time_update_rate>
+      <gravity>0 0 -9.8</gravity>
+      <!--   <gravity>0 0 0</gravity> -->
+    </physics>
+
+    <plugin filename="gz-sim-physics-system"
+            name="gz::sim::systems::Physics"/>
+    <plugin filename="gz-sim-user-commands-system"
+            name="gz::sim::systems::UserCommands"/>
+    <plugin filename="gz-sim-scene-broadcaster-system"
+            name="gz::sim::systems::SceneBroadcaster"/>
+    <plugin filename="gz-sim-contact-system"
+            name="gz::sim::systems::Contact"/>
+    <plugin filename="gz-sim-sensors-system"
+            name="gz::sim::systems::Sensors">
+      <render_engine>ogre2</render_engine>
+    </plugin>
+    <plugin filename="gz-sim-imu-system"
+            name="gz::sim::systems::Imu"/>
+
+    <!-- View persepective at startup -->
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose frame=''>4.70771 -4.35195 3.8148 0 0.575643 2.3522</pose>
+        <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+      </camera>
+    </gui>
+
+    <!-- Disable shadows, disable grid -->
+    <scene>
+      <shadows>false</shadows>
+      <ambient>0.2 0.2 0.2 1</ambient>
+      <background>1 1 1 1</background>
+      <grid>false</grid>
+      <origin_visual>false</origin_visual>
+    </scene>
+
+    <!-- A global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <!-- A directed light source -->
+    <light name="camera_spot_1_light" type='spot'>
+      <pose>-6 4 4 0 -1 -0.8</pose>
+      <diffuse>0.5 0.5 0.5 1</diffuse>
+      <specular>0.1 0.1 0.1 1</specular>
+      <direction>0 0 -1</direction>
+      <attenuation>
+        <range>20</range>
+        <constant>0.2</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <cast_shadows>0</cast_shadows>
+      <spot>
+        <inner_angle>0.6</inner_angle>
+        <outer_angle>1</outer_angle>
+        <falloff>1</falloff>
+      </spot>
+    </light>
+
+    <!-- A second directed light source -->
+    <light name="camera_spot_2_light" type='spot'>
+      <pose>5 -3 4 0 0.8 -0.6</pose>
+      <diffuse>0.5 0.5 0.5 1</diffuse>
+      <specular>0.1 0.1 0.1 1</specular>
+      <direction>0 0 -1</direction>
+      <attenuation>
+        <range>20</range>
+        <constant>0.3</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <cast_shadows>0</cast_shadows>
+      <spot>
+        <inner_angle>0.6</inner_angle>
+        <outer_angle>1</outer_angle>
+        <falloff>1</falloff>
+      </spot>
+    </light>
+
+    <!-- A wooden parquet ground plane -->
+    <!-- Centered on the maze's world-frame bounding box (x:[-2.5,3.5], y:[-3.5,2.5]) -->
+    <include>
+      <uri>model://floor_parquet2</uri>
+      <pose>0.5 -0.5 0 0 0 0</pose>
+    </include>
+
+    <!-- A maze made of plywood panels -->
+    <!-- Offset chosen so the robot spawn point (world 0,0) lands in the fully
+         open pass-through cell at local (2.5, 3.5) instead of inside a wall.
+         NOTE: this shifts the maze relative to maps/maze_3.yaml -- that Nav2
+         map was captured against the old offset and needs to be re-recorded
+         (or given a matching origin) before it is used for localization. -->
+    <include>
+      <uri>model://maze_3_6x6</uri>
+      <pose>-2.5 -3.5 0 0 0 0</pose>
+    </include>
+
+    <!-- A set of tag36h11 AprilTags that match the panel positions -->
+    <include>
+      <uri>model://maze_3_tags</uri>
+      <pose>-2.5 -3.5 0 0 0 0</pose>
+    </include>
+
+    <!-- Marcas de color: cubos con colision real (tambien son un obstaculo
+         fisico), ubicados en pasajes angostos verificados en el GUI de
+         Gazebo para que no queden a la vista desde el spawn. Posiciones
+         en coordenadas de mundo (no locales al maze); el offset conocido
+         de maze_3 (ver #10 / PR #22) es solo relevante para el mapa Nav2,
+         no afecta estas coordenadas absolutas. -->
+    <model name='marcas_color'>
+      <static>1</static>
+
+      <link name='cuadrado_rojo_1'>
+        <pose>0.0013 0.9937 0.15 0 0 0</pose>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.05 0.05 1</ambient>
+            <diffuse>0.8 0.05 0.05 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <link name='cuadrado_azul_1'>
+        <pose>0.9563 -1.9086 0.15 0 0 0</pose>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.05 0.05 0.8 1</ambient>
+            <diffuse>0.05 0.05 0.8 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <link name='cuadrado_rojo_2'>
+        <pose>2.9552 -2.0360 0.15 0 0 0</pose>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.05 0.05 1</ambient>
+            <diffuse>0.8 0.05 0.05 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <link name='cuadrado_azul_2'>
+        <pose>-0.0847 -2.9586 0.15 0 0 0</pose>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.05 0.05 0.8 1</ambient>
+            <diffuse>0.05 0.05 0.8 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <link name='cuadrado_rojo_3'>
+        <pose>-2.0847 -2.0202 0.15 0 0 0</pose>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.05 0.05 1</ambient>
+            <diffuse>0.8 0.05 0.05 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+  </world>
+</sdf>

--- a/yahboom_rosmaster_gazebo/worlds/maze_3_6x6_victimas.world
+++ b/yahboom_rosmaster_gazebo/worlds/maze_3_6x6_victimas.world
@@ -97,10 +97,7 @@
 
     <!-- A maze made of plywood panels -->
     <!-- Offset chosen so the robot spawn point (world 0,0) lands in the fully
-         open pass-through cell at local (2.5, 3.5) instead of inside a wall.
-         NOTE: this shifts the maze relative to maps/maze_3.yaml -- that Nav2
-         map was captured against the old offset and needs to be re-recorded
-         (or given a matching origin) before it is used for localization. -->
+         open pass-through cell at local (2.5, 3.5) instead of inside a wall. -->
     <include>
       <uri>model://maze_3_6x6</uri>
       <pose>-2.5 -3.5 0 0 0 0</pose>

--- a/yahboom_rosmaster_gazebo/worlds/maze_4_metal_6x6_victimas.world
+++ b/yahboom_rosmaster_gazebo/worlds/maze_4_metal_6x6_victimas.world
@@ -1,0 +1,216 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <world name="maze_4_metal_6x6_victimas">
+
+    <physics type="ode">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>1000</real_time_update_rate>
+      <gravity>0 0 -9.8</gravity>
+      <!--   <gravity>0 0 0</gravity> -->
+    </physics>
+
+    <plugin filename="gz-sim-physics-system"
+            name="gz::sim::systems::Physics"/>
+    <plugin filename="gz-sim-user-commands-system"
+            name="gz::sim::systems::UserCommands"/>
+    <plugin filename="gz-sim-scene-broadcaster-system"
+            name="gz::sim::systems::SceneBroadcaster"/>
+    <plugin filename="gz-sim-contact-system"
+            name="gz::sim::systems::Contact"/>
+    <plugin filename="gz-sim-sensors-system"
+            name="gz::sim::systems::Sensors">
+      <render_engine>ogre2</render_engine>
+    </plugin>
+    <plugin filename="gz-sim-imu-system"
+            name="gz::sim::systems::Imu"/>
+
+    <!-- View persepective at startup -->
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose frame=''>4.70771 -4.35195 3.8148 0 0.575643 2.3522</pose>
+        <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+      </camera>
+    </gui>
+
+    <!-- Disable shadows, disable grid -->
+    <scene>
+      <shadows>false</shadows>
+      <!-- high overall brightness of scene for objects with shadeless textures -->
+      <ambient>0.93 0.93 0.93 1</ambient>
+      <background>1 1 1 1</background>
+      <grid>false</grid>
+      <origin_visual>false</origin_visual>
+    </scene>
+
+    <!-- A global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <!-- A directed light source -->
+    <light name="camera_spot_1_light" type='spot'>
+      <pose>-6 4 4 0 -1 -0.8</pose>
+      <diffuse>0.5 0.5 0.5 1</diffuse>
+      <specular>0.1 0.1 0.1 1</specular>
+      <direction>0 0 -1</direction>
+      <attenuation>
+        <range>20</range>
+        <constant>0.2</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <cast_shadows>0</cast_shadows>
+      <spot>
+        <inner_angle>0.6</inner_angle>
+        <outer_angle>1</outer_angle>
+        <falloff>1</falloff>
+      </spot>
+    </light>
+
+    <!-- A second directed light source -->
+    <light name="camera_spot_2_light" type='spot'>
+      <pose>5 -3 4 0 0.8 -0.6</pose>
+      <diffuse>0.5 0.5 0.5 1</diffuse>
+      <specular>0.1 0.1 0.1 1</specular>
+      <direction>0 0 -1</direction>
+      <attenuation>
+        <range>20</range>
+        <constant>0.3</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <cast_shadows>0</cast_shadows>
+      <spot>
+        <inner_angle>0.6</inner_angle>
+        <outer_angle>1</outer_angle>
+        <falloff>1</falloff>
+      </spot>
+    </light>
+
+    <!-- A wooden parquet ground plane -->
+    <!-- Centered on the maze's world-frame bounding box (x:[-2.5,3.5], y:[-3.5,2.5]) -->
+    <include>
+      <uri>model://floor_parquet2</uri>
+      <pose>0.5 -0.5 0 0 0 0</pose>
+    </include>
+
+    <!-- A maze made of plywood panels -->
+    <!-- Offset chosen so the robot spawn point (world 0,0) lands in the fully
+         open pass-through cell at local (2.5, 3.5) instead of inside a wall. -->
+    <include>
+      <uri>model://maze_4_metal_6x6</uri>
+      <pose>-2.5 -3.5 0 0 0 0</pose>
+    </include>
+
+    <!-- A set of tag36h11 AprilTags that match the panel positions -->
+    <!--
+    <include>
+      <uri>model://maze_3_tags</uri>
+      <pose>-2.5 -3.5 0 0 0 0</pose>
+    </include>
+    -->
+
+    <!-- Marcas de color: cubos con colision real (tambien son un obstaculo
+         fisico), ubicados en pasajes angostos verificados en el GUI de
+         Gazebo para que no queden a la vista desde el spawn. Posiciones
+         en coordenadas de mundo (no locales al maze). -->
+    <model name='marcas_color'>
+      <static>1</static>
+
+      <link name='cuadrado_rojo_1'>
+        <pose>2.8712 0.0424 0.15 0 0 0</pose>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.05 0.05 1</ambient>
+            <diffuse>0.8 0.05 0.05 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <link name='cuadrado_azul_1'>
+        <pose>2.9382 -2.0381 0.15 0 0 0</pose>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.05 0.05 0.8 1</ambient>
+            <diffuse>0.05 0.05 0.8 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <link name='cuadrado_rojo_2'>
+        <pose>-0.9851 0.9609 0.15 0 0 0</pose>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.8 0.05 0.05 1</ambient>
+            <diffuse>0.8 0.05 0.05 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+
+      <link name='cuadrado_azul_2'>
+        <pose>-1.0404 -2.0497 0.15 0 0 0</pose>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>0.25 0.25 0.3</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.05 0.05 0.8 1</ambient>
+            <diffuse>0.05 0.05 0.8 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+  </world>
+</sdf>


### PR DESCRIPTION
## Summary

Adds the `_victimas` variant to the four maze worlds that didn't have one yet — `maze_1_6x5.world`, `maze_2_6x5.world`, `maze_3_6x6.world`, and `maze_4_metal_6x6.world` — following the same pattern already used by `laberinto_simple_victimas.world` and `laberinto_1_victimas.world`.

- One new `<name>_victimas.world` per maze, identical to the original plus color-marker cubes (0.25x0.25x0.3 m, with collision, mix of red and blue).
- Cube positions were chosen interactively in the Gazebo GUI (Insert + Component Inspector) and placed in narrow or hidden passages, not visible from the spawn point, so the robot has to search for them.
- Registers `world_smoke_maze_1_victimas`, `world_smoke_maze_2_victimas`, `world_smoke_maze_3_victimas`, and `world_smoke_maze_4_victimas` in `yahboom_rosmaster_gazebo/CMakeLists.txt`.
- Updates the "Maze Worlds" table in the README with the four new worlds.

`maze_3_6x6_victimas.world` cubes are placed in world-frame coordinates and were checked against the maze's known offset (#10 / #22) — they don't interfere with the existing wall/collision geometry.

## Test plan

- [x] All four `_victimas` worlds load without errors in Fortress.
- [x] `world_smoke_maze_{1,2,3,4}_victimas` pass (headless spawn, no initial collision, forward `/cmd_vel` produces real displacement, core topics up).
- [x] Full `colcon test` run (131 tests, 1 pre-existing unrelated failure in `yahboom_rosmaster_description`'s `robot_description_contract_test.py`, reproducible on `main` and unrelated to this change — passes 8/8 when run directly instead of through CTest).
- [x] Manual verification per map: drove the robot with `teleop_twist_keyboard`, confirmed each cube shows up in `/scan` as an isolated point cluster and in `/cam_1/color/image_raw` with the correct color, and confirmed physical collision by driving into them.
- [x] Full Development Checks from the README (`git diff --check`, `py_compile`, `xacro` + `check_urdf`, `colcon build`, `rosdep check`) all green.

Closes #23.
