### PR TITLE
Project board automations (auto-add, In review, block AI co-author)

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,17 @@
+name: Add to project
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    name: Add issue/PR to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/AIRclub-UdeSA/projects/3
+          github-token: ${{ secrets.ORG_PROJECT_TOKEN }}

--- a/.github/workflows/block-ai-coauthor.yml
+++ b/.github/workflows/block-ai-coauthor.yml
@@ -1,0 +1,27 @@
+name: Block AI co-author
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-commit-messages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Reject commits co-authored by Claude/Anthropic
+        run: |
+          set -e
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          BAD=$(git log "$BASE..$HEAD" --format="%H %B" | grep -iE "co-authored-by:.*claude|noreply@anthropic\.com" || true)
+          if [ -n "$BAD" ]; then
+            echo "Found commits co-authored by Claude/Anthropic:"
+            echo "$BAD"
+            echo
+            echo "Remove the 'Co-Authored-By: Claude ...' line from the commit message and push again."
+            exit 1
+          fi

--- a/.github/workflows/pr-review-status.yml
+++ b/.github/workflows/pr-review-status.yml
@@ -1,0 +1,59 @@
+name: Sync PR review status
+
+on:
+  pull_request:
+    types: [review_requested, review_request_removed]
+
+jobs:
+  set-in-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync project Status with review state
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.ORG_PROJECT_TOKEN }}
+          script: |
+            const projectId = "PVT_kwDOEjyD084BhtOr";
+            const statusFieldId = "PVTSSF_lADOEjyD084BhtOrzhgn_fY";
+            const statusOptionId = context.payload.action === "review_requested"
+              ? "5c347fba"  // In review
+              : "e4b255ff"; // In progress
+            const prNodeId = context.payload.pull_request.node_id;
+
+            const result = await github.graphql(
+              `query($prId: ID!) {
+                node(id: $prId) {
+                  ... on PullRequest {
+                    projectItems(first: 10) {
+                      nodes {
+                        id
+                        project { number }
+                      }
+                    }
+                  }
+                }
+              }`,
+              { prId: prNodeId }
+            );
+
+            const item = result.node.projectItems.nodes.find(n => n.project.number === 3);
+
+            if (!item) {
+              console.log("PR is not on project 3 yet, skipping.");
+              return;
+            }
+
+            await github.graphql(
+              `mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $project
+                  itemId: $item
+                  fieldId: $field
+                  value: { singleSelectOptionId: $option }
+                }) { projectV2Item { id } }
+              }`,
+              { project: projectId, item: item.id, field: statusFieldId, option: statusOptionId }
+            );
+
+            const statusName = context.payload.action === "review_requested" ? "In review" : "In progress";
+            console.log(`Status set to ${statusName} for PR #${context.payload.pull_request.number}`);


### PR DESCRIPTION
## Summary
Includes the 3 automations already validated/being validated in `jar_workshops`:

1. **Auto-add**: new issues and PRs get added automatically to the "JAR Challenge 2026" project (project 3).
2. **Review status sync**: requesting a reviewer on a PR sets Status to In review; removing the reviewer reverts it to In progress.
3. **AI co-author block**: fails the check if any commit carries a "Co-Authored-By: Claude" trailer or noreply@anthropic.com.

Automations 1 and 2 use the fine-grained PAT stored as an org secret (`ORG_PROJECT_TOKEN`).

**This PR stays in draft** until everything is validated in `jar_workshops` — will mark it ready once confirmed working, so it can be merged here.

## Test plan
- [x] Auto-add already tested end-to-end in jar_workshops
- [ ] Review status sync, pending test in jar_workshops
- [ ] Merge once validated