### PR TITLE
Migrate from PAT to GitHub App for Projects auth

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -11,7 +11,15 @@ jobs:
     name: Add issue/PR to project
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: AIRclub-UdeSA
+
       - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/AIRclub-UdeSA/projects/3
-          github-token: ${{ secrets.ORG_PROJECT_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/pr-review-status.yml
+++ b/.github/workflows/pr-review-status.yml
@@ -8,10 +8,18 @@ jobs:
   set-in-review:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: AIRclub-UdeSA
+
       - name: Sync project Status with review state
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.ORG_PROJECT_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const projectId = "PVT_kwDOEjyD084BhtOr";
             const statusFieldId = "PVTSSF_lADOEjyD084BhtOrzhgn_fY";


### PR DESCRIPTION
## Summary
Stage B of the automation plan: replaces the fine-grained PAT (Stage A) with the `airclub-projects-bot` GitHub App as the auth mechanism for writing to the project.

- Both workflows generate an installation token on the fly with `actions/create-github-app-token`, using the `APP_ID` and `APP_PRIVATE_KEY` org secrets.
- Doesn't depend on any individual member's account and doesn't expire like the PAT.

## Test plan
- [x] Already validated in jar_workshops
- [ ] Merge