### PR TITLE
fix: publish LiDAR and RGB-D sensor topics at Best Effort QoS

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,20 @@ header to the true frame before publishing `/cam_1/depth/color/points`.
 Topics under `/internal/` are implementation details: subscribe to the public
 contract topics instead.
 
+`/scan` and the five `/cam_1/*` topics above all publish Best Effort, matching
+the physical ROSMASTER X3's `qos_profile_sensor_data`/`SensorDataQoS`
+publishers (`yahboomcar_astra`, `sllidar_ros2`). Neither `ros_gz_bridge` nor
+`ros_gz_image` in this release can publish Best Effort directly, so each of
+these topics is bridged onto a private `/internal/...` name at the ROS 2
+default (Reliable) and a `sensor_qos_relay.py` instance (or, for the point
+cloud, `pointcloud_frame_relay.py`) republishes it under its public name at
+Best Effort. A consumer that subscribes Best Effort -- required for the
+physical robot -- receives no data from a Reliable-only publisher, so this
+keeps one consumer working against both environments without remaps or
+per-environment QoS overrides. `sensor_contract_probe.py` asserts this on
+every launch test via `validate_qos`. `/joint_states`, `/odom`, and
+`/imu/data` remain Reliable, also matching the physical robot.
+
 The current camera is an idealized, pre-registered, single-aperture RGB-D
 model. Fortress renders the combined color and depth streams from one pose, so
 all four image and camera-information topics use

--- a/yahboom_rosmaster_gazebo/CMakeLists.txt
+++ b/yahboom_rosmaster_gazebo/CMakeLists.txt
@@ -31,6 +31,7 @@ install(
     scripts/calculated_odometry.py
     scripts/ground_truth_tf.py
     scripts/pointcloud_frame_relay.py
+    scripts/sensor_qos_relay.py
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/yahboom_rosmaster_gazebo/config/ros_gz_bridge.yaml
+++ b/yahboom_rosmaster_gazebo/config/ros_gz_bridge.yaml
@@ -7,8 +7,11 @@
   direction: ROS_TO_GZ
   lazy: false
 
-# RGBD Camera topics
-- ros_topic_name: "cam_1/color/camera_info"
+# RGBD Camera topics. Neither parameter_bridge nor image_bridge in this
+# ros_gz release can publish Best Effort, so these land on private /internal/
+# names; sensor_qos_relay.py republishes them under the public contract
+# topic at Best Effort to match the physical robot's qos_profile_sensor_data.
+- ros_topic_name: "/internal/cam_1/color/camera_info"
   gz_topic_name: "/cam_1/camera_info"
   ros_type_name: "sensor_msgs/msg/CameraInfo"
   gz_type_name: "gz.msgs.CameraInfo"
@@ -17,7 +20,7 @@
   # Lazy aliases of the same Gazebo topic can race during display reconfiguration.
   lazy: false
 
-- ros_topic_name: "cam_1/depth/camera_info"
+- ros_topic_name: "/internal/cam_1/depth/camera_info"
   gz_topic_name: "/cam_1/camera_info"
   ros_type_name: "sensor_msgs/msg/CameraInfo"
   gz_type_name: "gz.msgs.CameraInfo"
@@ -35,8 +38,9 @@
   direction: GZ_TO_ROS
   lazy: true
 
-# LIDAR configuration
-- ros_topic_name: "scan"
+# LIDAR configuration. Bridged privately for the same Best Effort reason as
+# the camera topics above; sensor_qos_relay.py republishes the public /scan.
+- ros_topic_name: "/internal/scan"
   gz_topic_name: "scan"
   ros_type_name: "sensor_msgs/msg/LaserScan"
   gz_type_name: "gz.msgs.LaserScan"

--- a/yahboom_rosmaster_gazebo/launch/rosmaster_gazebo_fortress.launch.py
+++ b/yahboom_rosmaster_gazebo/launch/rosmaster_gazebo_fortress.launch.py
@@ -433,13 +433,16 @@ def generate_launch_description():
     )
 
     # Optimized image bridge for the native Fortress RGB-D camera outputs.
+    # image_bridge cannot publish Best Effort, so it lands on private
+    # /internal/ names; sensor_qos_relay nodes below republish them under the
+    # public contract topics at Best Effort to match the physical robot.
     ros_gz_image_bridge = Node(
         package="ros_gz_image",
         executable="image_bridge",
         arguments=["/cam_1/image", "/cam_1/depth_image"],
         remappings=[
-            ("/cam_1/image", "/cam_1/color/image_raw"),
-            ("/cam_1/depth_image", "/cam_1/depth/image_raw"),
+            ("/cam_1/image", "/internal/cam_1/color/image_raw"),
+            ("/cam_1/depth_image", "/internal/cam_1/depth/image_raw"),
         ],
         output="screen",
         condition=IfCondition(render_sensors),
@@ -448,7 +451,8 @@ def generate_launch_description():
     # Fortress 6.18 labels the RGB-D cloud with the optical frame even though
     # its XYZ data is +X-forward. Relabel the header to the true regular frame
     # so TF, RViz, and depth pipelines stay mutually consistent without
-    # collapsing the REP-104 optical rotation.
+    # collapsing the REP-104 optical rotation. Also fixes the cloud's QoS to
+    # Best Effort; see the module docstring.
     pointcloud_frame_relay = Node(
         package="yahboom_rosmaster_gazebo",
         executable="pointcloud_frame_relay.py",
@@ -456,6 +460,40 @@ def generate_launch_description():
         output="screen",
         condition=IfCondition(render_sensors),
     )
+
+    # Best Effort matches the physical robot's qos_profile_sensor_data for
+    # these same topics (yahboomcar_astra, sllidar_ros2), so a consumer built
+    # against one works against the other without remaps or QoS overrides.
+    def _sensor_qos_relay(name, msg_type, input_topic, output_topic, condition=None):
+        return Node(
+            package="yahboom_rosmaster_gazebo",
+            executable="sensor_qos_relay.py",
+            name=name,
+            output="screen",
+            parameters=[{
+                "msg_type": msg_type,
+                "input_topic": input_topic,
+                "output_topic": output_topic,
+            }],
+            condition=condition,
+        )
+
+    color_image_qos_relay = _sensor_qos_relay(
+        "color_image_qos_relay", "Image",
+        "/internal/cam_1/color/image_raw", "/cam_1/color/image_raw",
+        condition=IfCondition(render_sensors))
+    depth_image_qos_relay = _sensor_qos_relay(
+        "depth_image_qos_relay", "Image",
+        "/internal/cam_1/depth/image_raw", "/cam_1/depth/image_raw",
+        condition=IfCondition(render_sensors))
+    color_camera_info_qos_relay = _sensor_qos_relay(
+        "color_camera_info_qos_relay", "CameraInfo",
+        "/internal/cam_1/color/camera_info", "/cam_1/color/camera_info")
+    depth_camera_info_qos_relay = _sensor_qos_relay(
+        "depth_camera_info_qos_relay", "CameraInfo",
+        "/internal/cam_1/depth/camera_info", "/cam_1/depth/camera_info")
+    scan_qos_relay = _sensor_qos_relay(
+        "scan_qos_relay", "LaserScan", "/internal/scan", "/scan")
 
     # Load and activate the read-only joint state broadcaster. The spawner waits
     # longer than `ros2 control load_controller`, which helps GUI starts on busy
@@ -585,6 +623,11 @@ def generate_launch_description():
             ros_gz_bridge,
             ros_gz_image_bridge,
             pointcloud_frame_relay,
+            color_image_qos_relay,
+            depth_image_qos_relay,
+            color_camera_info_qos_relay,
+            depth_camera_info_qos_relay,
+            scan_qos_relay,
             joint_state_bridge,
             joint_state_throttle,
             cmd_vel_watchdog,

--- a/yahboom_rosmaster_gazebo/scripts/pointcloud_frame_relay.py
+++ b/yahboom_rosmaster_gazebo/scripts/pointcloud_frame_relay.py
@@ -9,11 +9,16 @@ the optical TF rotation) keeps image and calibration topics on the REP-104
 optical frame while giving the cloud the ``cam_1_depth_frame`` label its
 coordinates actually use, so RViz, TF consumers, and depth pipelines all
 agree.
+
+The public output also switches to Best Effort here: the physical robot
+publishes its point cloud as Best Effort (``qos_profile_sensor_data``), and
+ros_gz_bridge cannot publish that directly, so this relay is also where the
+QoS gets fixed to match the contract.
 """
 
 import rclpy
 from rclpy.node import Node
-from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
+from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy, qos_profile_sensor_data
 from sensor_msgs.msg import PointCloud2
 
 
@@ -34,13 +39,8 @@ class PointCloudFrameRelay(Node):
             durability=DurabilityPolicy.VOLATILE,
             reliability=ReliabilityPolicy.RELIABLE,
         )
-        qos_out = QoSProfile(
-            depth=5,
-            durability=DurabilityPolicy.VOLATILE,
-            reliability=ReliabilityPolicy.RELIABLE,
-        )
         self.publisher = self.create_publisher(PointCloud2, self.output_topic,
-                                               qos_out)
+                                               qos_profile_sensor_data)
         self.create_subscription(PointCloud2, self.input_topic,
                                  self.republish, qos_in)
         self.get_logger().info(

--- a/yahboom_rosmaster_gazebo/scripts/sensor_contract_probe.py
+++ b/yahboom_rosmaster_gazebo/scripts/sensor_contract_probe.py
@@ -36,6 +36,18 @@ TIMESTAMPED_TF_TOPICS = (
     "/cam_1/depth/color/points",
     "/odom",
 )
+# The physical robot publishes every raw sensor stream as Best Effort
+# (qos_profile_sensor_data in yahboomcar_astra, SensorDataQoS in
+# sllidar_ros2). A consumer built for that contract silently receives
+# nothing from a Reliable topic, so the simulator must match here too.
+BEST_EFFORT_TOPICS = (
+    "/scan",
+    "/cam_1/color/image_raw",
+    "/cam_1/depth/image_raw",
+    "/cam_1/color/camera_info",
+    "/cam_1/depth/camera_info",
+    "/cam_1/depth/color/points",
+)
 
 
 def validated_sample_count(value):
@@ -196,6 +208,20 @@ class SensorContractProbe(Node):
         if any(not message.header.frame_id for message in messages):
             errors.append(f"{topic}: frame_id is empty")
 
+    def validate_qos(self, topic, errors):
+        """Require the topic's publisher(s) to match the physical robot's QoS."""
+        infos = self.get_publishers_info_by_topic(topic)
+        if not infos:
+            errors.append(f"{topic}: no publisher info available for QoS check")
+            return
+        for info in infos:
+            reliability = info.qos_profile.reliability
+            if reliability != ReliabilityPolicy.BEST_EFFORT:
+                errors.append(
+                    f"{topic}: publisher '{info.node_name}' uses "
+                    f"{reliability.name} QoS, expected BEST_EFFORT to match "
+                    "the physical robot")
+
     def validate_rate(self, topic, minimum, maximum, errors):
         """Validate nominal rate from simulation timestamps."""
         stamps = [self.stamp_seconds(message) for message in self.messages[topic]]
@@ -264,6 +290,9 @@ class SensorContractProbe(Node):
         )
         for topic in header_topics:
             self.validate_header(topic, errors)
+
+        for topic in BEST_EFFORT_TOPICS:
+            self.validate_qos(topic, errors)
 
         rate_contracts = {
             "/scan": (4.5, 5.5),

--- a/yahboom_rosmaster_gazebo/scripts/sensor_qos_relay.py
+++ b/yahboom_rosmaster_gazebo/scripts/sensor_qos_relay.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+Republish one bridged sensor topic from Reliable to Best Effort.
+
+Neither ros_gz_bridge's parameter_bridge nor ros_gz_image's image_bridge in
+this release expose a per-topic QoS override, so every Gazebo-bridged topic
+publishes at the ROS 2 default (Reliable). The physical ROSMASTER X3
+publishes every raw sensor stream -- LiDAR and both RGB-D image/camera_info
+pairs -- as Best Effort (``qos_profile_sensor_data``); a consumer built for
+that contract silently receives nothing from a Reliable topic. This node
+relays one bridged /internal/... topic to its public contract name at Best
+Effort so the same consumer works against sim and hardware without remaps.
+"""
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import qos_profile_sensor_data
+from sensor_msgs.msg import CameraInfo, Image, LaserScan
+
+MESSAGE_TYPES = {
+    "Image": Image,
+    "CameraInfo": CameraInfo,
+    "LaserScan": LaserScan,
+}
+
+
+class SensorQosRelay(Node):
+    """Bridge-side QoS fix: Reliable /internal/... topic -> Best Effort public topic."""
+
+    def __init__(self):
+        super().__init__("sensor_qos_relay")
+        self.declare_parameter("msg_type", "")
+        self.declare_parameter("input_topic", "")
+        self.declare_parameter("output_topic", "")
+
+        msg_type_name = self.get_parameter("msg_type").value
+        if msg_type_name not in MESSAGE_TYPES:
+            raise ValueError(
+                f"Unsupported msg_type {msg_type_name!r}; expected one of "
+                f"{sorted(MESSAGE_TYPES)}")
+        message_type = MESSAGE_TYPES[msg_type_name]
+
+        self.input_topic = self.get_parameter("input_topic").value
+        self.output_topic = self.get_parameter("output_topic").value
+        if not self.input_topic or not self.output_topic:
+            raise ValueError("input_topic and output_topic are required")
+
+        self.publisher = self.create_publisher(
+            message_type, self.output_topic, qos_profile_sensor_data)
+        self.create_subscription(
+            message_type, self.input_topic, self.republish, 10)
+        self.get_logger().info(
+            f"Relaying {self.input_topic} to {self.output_topic} at Best Effort QoS")
+
+    def republish(self, message):
+        self.publisher.publish(message)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = SensorQosRelay()
+    try:
+        rclpy.spin(node)
+    except (KeyboardInterrupt, SystemExit):
+        pass
+    finally:
+        node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Found while re-checking the sim/physical topic tree against `physical_rosmaster`'s `config/robot_contract.yaml` (pinned to `772ba25`): `/scan` and all five `/cam_1/*` topics here publish at the ROS 2 default (Reliable), but the physical ROSMASTER X3 publishes every one of them at Best Effort (`qos_profile_sensor_data` in `yahboomcar_astra`, `SensorDataQoS` in `sllidar_ros2`).

Reliable and Best Effort are QoS-incompatible in one direction: a Best-Effort subscriber gets data from either kind of publisher, but a Reliable (default) subscriber gets **nothing** from a Best Effort publisher, silently. Since a consumer must subscribe Best Effort to work on the physical robot, that same consumer was silently receiving no data here — exactly what the Sim2Real consumer-parity gate is supposed to catch.

## Change

- `/scan`, `/cam_1/{color,depth}/image_raw`, `/cam_1/{color,depth}/camera_info`, `/cam_1/depth/color/points` now all publish Best Effort on their public names.
- Neither `ros_gz_bridge`'s `parameter_bridge` nor `ros_gz_image`'s `image_bridge` in this release expose a per-topic QoS override (checked upstream source directly), so each of these is bridged onto a private `/internal/...` name at Reliable (unavoidable) and republished under its public name at Best Effort by a small relay node — extending the pattern `pointcloud_frame_relay.py` already established for the point cloud (which gets the same QoS fix here).
- New `sensor_qos_relay.py` is a generic single-topic relay (`msg_type`/`input_topic`/`output_topic` params), launched once per topic instead of five near-duplicate files.
- `sensor_contract_probe.py` gets a `validate_qos()` check via `get_publishers_info_by_topic`, run unconditionally (including the CI-mode target) for all six topics, so a regression here fails the contract instead of only showing up as silent no-data on hardware.
- README's topic-table section documents which topics are Best Effort/Reliable and why.

## Verification

I don't have a Gazebo Fortress environment here, so I could not run the full launch/CI test suite locally. What I did verify:

- `python3 -m py_compile` on every changed/new Python file, and a YAML parse of `ros_gz_bridge.yaml`.
- A standalone `rclpy` test (Reliable publisher on `/internal/scan` → `SensorQosRelay` → confirmed the public `/scan` publisher reports `BEST_EFFORT` and a Best-Effort subscriber actually receives the message).
- A standalone test of `SensorContractProbe.validate_qos` against a real Reliable publisher (correctly flagged) and a real Best Effort publisher (correctly passed).
- Checked every existing probe that subscribes to these six topics (`world_smoke_probe.py`, `lidar_geometry_probe.py`, `depth_geometry_probe.py`, `sensor_contract_probe.py`) — all of them already subscribe Best Effort (`sensor_qos`/`best_effort_qos`), so none of them break; if anything this fix is what those probes' own QoS choice was anticipating.
- Checked `test/sensor_contract_probe_test.py` (offline unit test) — it never calls `validate()`/`validate_qos()`, so it's unaffected.

This PR's own `Simulator contracts` CI workflow builds the full workspace and runs `sensor_contract_ci` (and friends) against real Gazebo Fortress, which is the actual validation this needs — please treat a green run there as the real confirmation, not just this description.

## Test plan

- [ ] `Simulator contracts` CI passes on this PR
- [ ] `ros2 topic info -v /scan` and `/cam_1/color/image_raw` on a manual run show `RELIABILITY: BEST_EFFORT` for the public topic publisher
- [ ] RViz (or another Best-Effort-subscribing consumer) still shows LiDAR/RGB-D data live
