### PR TITLE
Sync Status with assignees and propagate review to the linked issue

### DIFF
--- a/.github/workflows/assignee-status.yml
+++ b/.github/workflows/assignee-status.yml
@@ -1,0 +1,118 @@
+name: Sync assignee status
+
+on:
+  issues:
+    types: [assigned, unassigned]
+  pull_request:
+    types: [assigned, unassigned]
+
+jobs:
+  set-in-progress:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: AIRclub-UdeSA
+
+      - name: Sync project Status with assignees
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const projectId = "PVT_kwDOEjyD084BhtOr";
+            const statusFieldId = "PVTSSF_lADOEjyD084BhtOrzhgn_fY";
+            const inProgressOptionId = "e4b255ff";
+            const readyOptionId = "e910ce1a";
+            // Don't overwrite statuses that represent a later stage of the work
+            const keepOptionIds = [
+              "5c347fba", // In review
+              "85dd6979", // Done
+              "7cef383f", // Blocked
+            ];
+
+            const content = context.payload.issue || context.payload.pull_request;
+            const isAssign = context.payload.action === "assigned";
+            const remainingAssignees = (content.assignees || []).length;
+
+            // On unassign, only go back to Ready if nobody else is assigned
+            if (!isAssign && remainingAssignees > 0) {
+              console.log(`Still ${remainingAssignees} assignee(s), leaving status as is.`);
+              return;
+            }
+
+            // The assignee event can arrive before auto-add has put the item
+            // on the project (happens when creating an issue that is already
+            // assigned). Retry instead of giving up on the first attempt.
+            const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+
+            const query = `query($id: ID!) {
+                node(id: $id) {
+                  ... on Issue {
+                    projectItems(first: 10) {
+                      nodes {
+                        id
+                        project { number }
+                        fieldValueByName(name: "Status") {
+                          ... on ProjectV2ItemFieldSingleSelectValue { name optionId }
+                        }
+                      }
+                    }
+                  }
+                  ... on PullRequest {
+                    projectItems(first: 10) {
+                      nodes {
+                        id
+                        project { number }
+                        fieldValueByName(name: "Status") {
+                          ... on ProjectV2ItemFieldSingleSelectValue { name optionId }
+                        }
+                      }
+                    }
+                  }
+                }
+              }`;
+
+            let item = null;
+
+            for (let attempt = 1; attempt <= 5; attempt++) {
+              const result = await github.graphql(query, { id: content.node_id });
+              item = result.node.projectItems.nodes.find(n => n.project.number === 3);
+              if (item) break;
+              if (attempt < 5) {
+                console.log(`Item not on project 3 yet (attempt ${attempt}/5), waiting 3s...`);
+                await sleep(3000);
+              }
+            }
+
+            if (!item) {
+              console.log("Item never showed up on project 3, skipping.");
+              return;
+            }
+
+            const current = item.fieldValueByName;
+
+            if (current && keepOptionIds.includes(current.optionId)) {
+              console.log(`Status is already "${current.name}", leaving it as is.`);
+              return;
+            }
+
+            const targetOptionId = isAssign ? inProgressOptionId : readyOptionId;
+
+            await github.graphql(
+              `mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $project
+                  itemId: $item
+                  fieldId: $field
+                  value: { singleSelectOptionId: $option }
+                }) { projectV2Item { id } }
+              }`,
+              { project: projectId, item: item.id, field: statusFieldId, option: targetOptionId }
+            );
+
+            const statusName = isAssign ? "In progress" : "Ready";
+            console.log(`Status set to ${statusName} for #${content.number}`);

--- a/.github/workflows/pr-review-status.yml
+++ b/.github/workflows/pr-review-status.yml
@@ -28,8 +28,12 @@ jobs:
               : "e4b255ff"; // In progress
             const prNodeId = context.payload.pull_request.node_id;
 
-            const result = await github.graphql(
-              `query($prId: ID!) {
+            // The review event can arrive before auto-add has put the PR on
+            // the project (happens when opening a PR with a reviewer already
+            // filled in). Retry instead of giving up on the first attempt.
+            const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+
+            const query = `query($prId: ID!) {
                 node(id: $prId) {
                   ... on PullRequest {
                     projectItems(first: 10) {
@@ -38,30 +42,70 @@ jobs:
                         project { number }
                       }
                     }
+                    closingIssuesReferences(first: 10) {
+                      nodes {
+                        number
+                        projectItems(first: 10) {
+                          nodes {
+                            id
+                            project { number }
+                          }
+                        }
+                      }
+                    }
                   }
                 }
-              }`,
-              { prId: prNodeId }
-            );
+              }`;
 
-            const item = result.node.projectItems.nodes.find(n => n.project.number === 3);
+            const itemOnProject = (items) => items.nodes.find(n => n.project.number === 3);
 
-            if (!item) {
-              console.log("PR is not on project 3 yet, skipping.");
+            // Move the PR and also the issues it will close: otherwise the
+            // issue sits in In progress while the work is waiting for review
+            let targets = [];
+
+            for (let attempt = 1; attempt <= 5; attempt++) {
+              const result = await github.graphql(query, { prId: prNodeId });
+              const pr = result.node;
+              targets = [];
+
+              const prItem = itemOnProject(pr.projectItems);
+              if (prItem) {
+                targets.push({ id: prItem.id, label: `PR #${context.payload.pull_request.number}` });
+              }
+
+              for (const issue of pr.closingIssuesReferences.nodes) {
+                const issueItem = itemOnProject(issue.projectItems);
+                if (issueItem) {
+                  targets.push({ id: issueItem.id, label: `issue #${issue.number}` });
+                }
+              }
+
+              if (targets.length > 0) break;
+              if (attempt < 5) {
+                console.log(`Nothing on project 3 yet (attempt ${attempt}/5), waiting 3s...`);
+                await sleep(3000);
+              }
+            }
+
+            if (targets.length === 0) {
+              console.log("Neither the PR nor its linked issues showed up on project 3, skipping.");
               return;
             }
 
-            await github.graphql(
-              `mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
-                updateProjectV2ItemFieldValue(input: {
-                  projectId: $project
-                  itemId: $item
-                  fieldId: $field
-                  value: { singleSelectOptionId: $option }
-                }) { projectV2Item { id } }
-              }`,
-              { project: projectId, item: item.id, field: statusFieldId, option: statusOptionId }
-            );
-
             const statusName = context.payload.action === "review_requested" ? "In review" : "In progress";
-            console.log(`Status set to ${statusName} for PR #${context.payload.pull_request.number}`);
+
+            for (const target of targets) {
+              await github.graphql(
+                `mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $project
+                    itemId: $item
+                    fieldId: $field
+                    value: { singleSelectOptionId: $option }
+                  }) { projectV2Item { id } }
+                }`,
+                { project: projectId, item: target.id, field: statusFieldId, option: statusOptionId }
+              );
+
+              console.log(`Status set to ${statusName} for ${target.label}`);
+            }


### PR DESCRIPTION
## Summary
Replica of what was already validated end-to-end in `jar_workshops`.

### 1. New: `assignee-status.yml`
- **Someone is assigned** → `In progress`
- **Someone is unassigned** → back to `Ready`, only if nobody else is assigned
- **Guard**: won't overwrite `In review`, `Done` or `Blocked`

### 2. Fix: `pr-review-status.yml` propagates to the linked issue
It used to move only the PR's item, so the issue that PR closes stayed in `In progress` for the whole review window — and the issue is what people look at on the board. Now it also moves the issues in `closingIssuesReferences`, in both directions.

### 3. Retries in both
The event can arrive before auto-add has put the item on the board (happens when creating an issue that's already assigned, or opening a PR with a reviewer already filled in). Retries 5 times with a 3s wait before giving up.

## Validation
Tested in `jar_workshops`: assign → In progress, unassign → Ready, PR+issue → In review, removing the reviewer → both back to In progress, guard respected, and the retry path verified by forcing the condition.

Note: the pre-existing `Simulator contracts` check is flaky in this repo (see #31) and unrelated to these changes.