### PR TITLE
Use the organization's shared workflows instead of local copies

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,3 +1,5 @@
+# Caller for the shared workflow in AIRclub-UdeSA/.github
+# Setup checklist: https://github.com/AIRclub-UdeSA/.github/blob/main/CONTRIBUTING.md#setting-up-a-new-repository
 name: Add to project
 
 on:
@@ -8,18 +10,7 @@ on:
 
 jobs:
   add-to-project:
-    name: Add issue/PR to project
-    runs-on: ubuntu-latest
-    steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: AIRclub-UdeSA
-
-      - uses: actions/add-to-project@v1.0.2
-        with:
-          project-url: https://github.com/orgs/AIRclub-UdeSA/projects/3
-          github-token: ${{ steps.app-token.outputs.token }}
+    uses: AIRclub-UdeSA/.github/.github/workflows/add-to-project.yml@main
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/assignee-status.yml
+++ b/.github/workflows/assignee-status.yml
@@ -1,3 +1,5 @@
+# Caller for the shared workflow in AIRclub-UdeSA/.github
+# Setup checklist: https://github.com/AIRclub-UdeSA/.github/blob/main/CONTRIBUTING.md#setting-up-a-new-repository
 name: Sync assignee status
 
 on:
@@ -8,111 +10,7 @@ on:
 
 jobs:
   set-in-progress:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: AIRclub-UdeSA
-
-      - name: Sync project Status with assignees
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          script: |
-            const projectId = "PVT_kwDOEjyD084BhtOr";
-            const statusFieldId = "PVTSSF_lADOEjyD084BhtOrzhgn_fY";
-            const inProgressOptionId = "e4b255ff";
-            const readyOptionId = "e910ce1a";
-            // Don't overwrite statuses that represent a later stage of the work
-            const keepOptionIds = [
-              "5c347fba", // In review
-              "85dd6979", // Done
-              "7cef383f", // Blocked
-            ];
-
-            const content = context.payload.issue || context.payload.pull_request;
-            const isAssign = context.payload.action === "assigned";
-            const remainingAssignees = (content.assignees || []).length;
-
-            // On unassign, only go back to Ready if nobody else is assigned
-            if (!isAssign && remainingAssignees > 0) {
-              console.log(`Still ${remainingAssignees} assignee(s), leaving status as is.`);
-              return;
-            }
-
-            // The assignee event can arrive before auto-add has put the item
-            // on the project (happens when creating an issue that is already
-            // assigned). Retry instead of giving up on the first attempt.
-            const sleep = (ms) => new Promise(r => setTimeout(r, ms));
-
-            const query = `query($id: ID!) {
-                node(id: $id) {
-                  ... on Issue {
-                    projectItems(first: 10) {
-                      nodes {
-                        id
-                        project { number }
-                        fieldValueByName(name: "Status") {
-                          ... on ProjectV2ItemFieldSingleSelectValue { name optionId }
-                        }
-                      }
-                    }
-                  }
-                  ... on PullRequest {
-                    projectItems(first: 10) {
-                      nodes {
-                        id
-                        project { number }
-                        fieldValueByName(name: "Status") {
-                          ... on ProjectV2ItemFieldSingleSelectValue { name optionId }
-                        }
-                      }
-                    }
-                  }
-                }
-              }`;
-
-            let item = null;
-
-            for (let attempt = 1; attempt <= 5; attempt++) {
-              const result = await github.graphql(query, { id: content.node_id });
-              item = result.node.projectItems.nodes.find(n => n.project.number === 3);
-              if (item) break;
-              if (attempt < 5) {
-                console.log(`Item not on project 3 yet (attempt ${attempt}/5), waiting 3s...`);
-                await sleep(3000);
-              }
-            }
-
-            if (!item) {
-              console.log("Item never showed up on project 3, skipping.");
-              return;
-            }
-
-            const current = item.fieldValueByName;
-
-            if (current && keepOptionIds.includes(current.optionId)) {
-              console.log(`Status is already "${current.name}", leaving it as is.`);
-              return;
-            }
-
-            const targetOptionId = isAssign ? inProgressOptionId : readyOptionId;
-
-            await github.graphql(
-              `mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
-                updateProjectV2ItemFieldValue(input: {
-                  projectId: $project
-                  itemId: $item
-                  fieldId: $field
-                  value: { singleSelectOptionId: $option }
-                }) { projectV2Item { id } }
-              }`,
-              { project: projectId, item: item.id, field: statusFieldId, option: targetOptionId }
-            );
-
-            const statusName = isAssign ? "In progress" : "Ready";
-            console.log(`Status set to ${statusName} for #${content.number}`);
+    uses: AIRclub-UdeSA/.github/.github/workflows/assignee-status.yml@main
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/block-ai-coauthor.yml
+++ b/.github/workflows/block-ai-coauthor.yml
@@ -1,3 +1,5 @@
+# Caller for the shared workflow in AIRclub-UdeSA/.github
+# Setup checklist: https://github.com/AIRclub-UdeSA/.github/blob/main/CONTRIBUTING.md#setting-up-a-new-repository
 name: Block AI co-author
 
 on:
@@ -6,22 +8,4 @@ on:
 
 jobs:
   check-commit-messages:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Reject commits co-authored by Claude/Anthropic
-        run: |
-          set -e
-          BASE="${{ github.event.pull_request.base.sha }}"
-          HEAD="${{ github.event.pull_request.head.sha }}"
-          BAD=$(git log "$BASE..$HEAD" --format="%H %B" | grep -iE "co-authored-by:.*claude|noreply@anthropic\.com" || true)
-          if [ -n "$BAD" ]; then
-            echo "Found commits co-authored by Claude/Anthropic:"
-            echo "$BAD"
-            echo
-            echo "Remove the 'Co-Authored-By: Claude ...' line from the commit message and push again."
-            exit 1
-          fi
+    uses: AIRclub-UdeSA/.github/.github/workflows/block-ai-coauthor.yml@main

--- a/.github/workflows/pr-review-status.yml
+++ b/.github/workflows/pr-review-status.yml
@@ -1,3 +1,5 @@
+# Caller for the shared workflow in AIRclub-UdeSA/.github
+# Setup checklist: https://github.com/AIRclub-UdeSA/.github/blob/main/CONTRIBUTING.md#setting-up-a-new-repository
 name: Sync PR review status
 
 on:
@@ -6,106 +8,7 @@ on:
 
 jobs:
   set-in-review:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: AIRclub-UdeSA
-
-      - name: Sync project Status with review state
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          script: |
-            const projectId = "PVT_kwDOEjyD084BhtOr";
-            const statusFieldId = "PVTSSF_lADOEjyD084BhtOrzhgn_fY";
-            const statusOptionId = context.payload.action === "review_requested"
-              ? "5c347fba"  // In review
-              : "e4b255ff"; // In progress
-            const prNodeId = context.payload.pull_request.node_id;
-
-            // The review event can arrive before auto-add has put the PR on
-            // the project (happens when opening a PR with a reviewer already
-            // filled in). Retry instead of giving up on the first attempt.
-            const sleep = (ms) => new Promise(r => setTimeout(r, ms));
-
-            const query = `query($prId: ID!) {
-                node(id: $prId) {
-                  ... on PullRequest {
-                    projectItems(first: 10) {
-                      nodes {
-                        id
-                        project { number }
-                      }
-                    }
-                    closingIssuesReferences(first: 10) {
-                      nodes {
-                        number
-                        projectItems(first: 10) {
-                          nodes {
-                            id
-                            project { number }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }`;
-
-            const itemOnProject = (items) => items.nodes.find(n => n.project.number === 3);
-
-            // Move the PR and also the issues it will close: otherwise the
-            // issue sits in In progress while the work is waiting for review
-            let targets = [];
-
-            for (let attempt = 1; attempt <= 5; attempt++) {
-              const result = await github.graphql(query, { prId: prNodeId });
-              const pr = result.node;
-              targets = [];
-
-              const prItem = itemOnProject(pr.projectItems);
-              if (prItem) {
-                targets.push({ id: prItem.id, label: `PR #${context.payload.pull_request.number}` });
-              }
-
-              for (const issue of pr.closingIssuesReferences.nodes) {
-                const issueItem = itemOnProject(issue.projectItems);
-                if (issueItem) {
-                  targets.push({ id: issueItem.id, label: `issue #${issue.number}` });
-                }
-              }
-
-              if (targets.length > 0) break;
-              if (attempt < 5) {
-                console.log(`Nothing on project 3 yet (attempt ${attempt}/5), waiting 3s...`);
-                await sleep(3000);
-              }
-            }
-
-            if (targets.length === 0) {
-              console.log("Neither the PR nor its linked issues showed up on project 3, skipping.");
-              return;
-            }
-
-            const statusName = context.payload.action === "review_requested" ? "In review" : "In progress";
-
-            for (const target of targets) {
-              await github.graphql(
-                `mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
-                  updateProjectV2ItemFieldValue(input: {
-                    projectId: $project
-                    itemId: $item
-                    fieldId: $field
-                    value: { singleSelectOptionId: $option }
-                  }) { projectV2Item { id } }
-                }`,
-                { project: projectId, item: target.id, field: statusFieldId, option: statusOptionId }
-              );
-
-              console.log(`Status set to ${statusName} for ${target.label}`);
-            }
+    uses: AIRclub-UdeSA/.github/.github/workflows/pr-review-status.yml@main
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
Replaces the four inline automations with callers to the org's `.github` repository, where the logic now lives once (AIRclub-UdeSA/.github#2).

**245 fewer lines** in this repo. The triggers still live here — each repo decides *when* they run; only *what they do* is shared.

## Validation
Tested end-to-end in `jar_workshops` (PR #37): all four automations work through the shared workflow — the PR was added to the board on its own, the co-author check passed, assigning someone moved it to In progress, and requesting a review moved it to In review.