### PR TITLE
ci: switch project-sync workflows to pull_request_target

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -5,7 +5,11 @@ name: Add to project
 on:
   issues:
     types: [opened]
-  pull_request:
+  # pull_request_target (not pull_request): fork PRs get no repo secrets on
+  # pull_request, so the App token step fails for every external
+  # contribution. Safe here because this workflow never checks out the
+  # fork's code and only calls the Projects GraphQL API.
+  pull_request_target:
     types: [opened]
 
 jobs:

--- a/.github/workflows/assignee-status.yml
+++ b/.github/workflows/assignee-status.yml
@@ -5,7 +5,11 @@ name: Sync assignee status
 on:
   issues:
     types: [assigned, unassigned]
-  pull_request:
+  # pull_request_target (not pull_request): fork PRs get no repo secrets on
+  # pull_request, so the App token step fails for every external
+  # contribution. Safe here because this workflow never checks out the
+  # fork's code and only calls the Projects GraphQL API.
+  pull_request_target:
     types: [assigned, unassigned]
 
 jobs:

--- a/.github/workflows/pr-review-status.yml
+++ b/.github/workflows/pr-review-status.yml
@@ -3,7 +3,11 @@
 name: Sync PR review status
 
 on:
-  pull_request:
+  # pull_request_target (not pull_request): fork PRs get no repo secrets on
+  # pull_request, so the App token step fails for every external
+  # contribution. Safe here because this workflow never checks out the
+  # fork's code and only calls the Projects GraphQL API.
+  pull_request_target:
     types: [review_requested, review_request_removed]
 
 jobs:


### PR DESCRIPTION
## Why

`assignee-status.yml` and `pr-review-status.yml` both trigger on the plain
`pull_request` event. GitHub Actions withholds repository secrets from
`pull_request`-triggered runs whenever the PR's head is a fork, so
`actions/create-github-app-token` fails immediately with `Input required and
not supplied: app-id` for every external contributor's PR.

Confirmed on #28 (a fork PR): all four `set-in-progress`/`set-in-review` runs
failed this way. #35 moved the job bodies into a shared reusable workflow in
`AIRclub-UdeSA/.github`, but that didn't help — the trigger and secret
forwarding (`secrets: APP_ID: ${{ secrets.APP_ID }}`) were unchanged, so the
caller still resolves an empty secret before it ever reaches the callee.
Re-running the failed `pr-review-status` check on #28 after #35 merged
reproduced the identical failure, confirming the refactor alone doesn't fix
it.

## What changes

Both workflows now trigger on `pull_request_target` instead of
`pull_request`. `pull_request_target` runs with the base repository's
permissions and secrets even when the head is a fork.

This is safe for these two workflows specifically: neither checks out the
fork's code (no `actions/checkout` step) or runs shell commands built from
PR-controlled input. Both only call `actions/github-script`, which reads
`context.payload` fields (PR/issue node IDs, assignee counts, the event
action) and passes them as GraphQL variables to the Projects API — never
string-interpolated into a shell command or query text.

## Validation

Re-ran the previously-failing `pr-review-status` check on #28 before this
fix (to confirm #35 didn't already resolve it) — same `app-id` failure.
Once merged, the next assignee/review-request event on a fork PR should
succeed; will confirm against #28 or the next external PR.